### PR TITLE
Click on progress bar to seek pos in current song

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -17,8 +17,20 @@ import {Socket} from "phoenix"
 import NProgress from "nprogress"
 import {LiveSocket} from "phoenix_live_view"
 
+let Hooks = {}
+
+Hooks.ProgressBar = {
+  mounted() {
+    this.el.addEventListener("click", e => {
+      const positionMs = Math.floor(e.target.max * e.offsetX / e.target.offsetWidth);
+
+      this.pushEvent("seek", {position_ms: positionMs});
+    });
+  }
+}
+
 let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
-let liveSocket = new LiveSocket("/live", Socket, {params: {_csrf_token: csrfToken}})
+let liveSocket = new LiveSocket("/live", Socket, {params: {_csrf_token: csrfToken}, hooks: Hooks})
 
 // Show progress bar on live navigation and form submits
 window.addEventListener("phx:page-loading-start", info => NProgress.start())

--- a/lib/tune/spotify/http_api.ex
+++ b/lib/tune/spotify/http_api.ex
@@ -2,6 +2,7 @@ defmodule Tune.Spotify.HttpApi do
   @moduledoc false
   alias Tune.Spotify.Schema.{Album, Artist, Episode, Player, Publisher, Show, Track, User}
   alias Tune.Spotify.Auth
+  alias Tune.Duration
   alias Ueberauth.Auth.Credentials
 
   require Logger
@@ -113,6 +114,25 @@ defmodule Tune.Spotify.HttpApi do
   @spec prev(token()) :: :ok | {:error, term()}
   def prev(token) do
     case post(@base_url <> "/me/player/previous", <<>>, auth_headers(token)) do
+      {:ok, %{status: 204}} ->
+        :ok
+
+      other_response ->
+        handle_errors(other_response)
+    end
+  end
+
+  @spec seek(token(), Duration.milliseconds()) :: :ok | {:error, term()}
+  def seek(token, position_ms) do
+    params = %{
+      position_ms: position_ms
+    }
+
+    case put(
+           @base_url <> "/me/player/seek?" <> URI.encode_query(params),
+           <<>>,
+           auth_headers(token)
+         ) do
       {:ok, %{status: 204}} ->
         :ok
 

--- a/lib/tune/spotify/session.ex
+++ b/lib/tune/spotify/session.ex
@@ -4,6 +4,7 @@ defmodule Tune.Spotify.Session do
   """
   alias Phoenix.PubSub
 
+  alias Tune.Duration
   alias Tune.Spotify.{HttpApi, Schema}
 
   @type id :: String.t()
@@ -18,6 +19,7 @@ defmodule Tune.Spotify.Session do
   @callback toggle_play(id()) :: :ok | {:error, term()}
   @callback play(id(), uri()) :: :ok | {:error, term()}
   @callback next(id()) :: :ok | {:error, term()}
+  @callback seek(id(), Duration.milliseconds()) :: :ok | {:error, term()}
   @callback prev(id()) :: :ok | {:error, term()}
   @callback search(id(), HttpApi.q(), HttpApi.search_options()) ::
               {:ok, HttpApi.search_results()} | {:error, term()}

--- a/lib/tune_web/live/explorer_live.ex
+++ b/lib/tune_web/live/explorer_live.ex
@@ -149,6 +149,12 @@ defmodule TuneWeb.ExplorerLive do
     |> handle_device_operation_result(socket)
   end
 
+  def handle_event("seek", %{"position_ms" => position_ms}, socket) do
+    socket.assigns.session_id
+    |> spotify().seek(position_ms)
+    |> handle_device_operation_result(socket)
+  end
+
   def handle_event("search", params, socket) do
     q = Map.get(params, "q")
     type = Map.get(params, "type", "track")

--- a/lib/tune_web/templates/player/progress.html.eex
+++ b/lib/tune_web/templates/player/progress.html.eex
@@ -1,6 +1,6 @@
 <div class="progress">
   <span class="duration"><%= Tune.Duration.hms(@progress_ms) %></span>
   <%= content_tag :label, gettext("Current track position"), for: "progress-bar", class: "visually-hidden" %>
-  <progress id="progress-bar" value="<%= @progress_ms %>" max="<%= @item.duration_ms %>"><%= Tune.Duration.hms(@progress_ms) %></progress>
+  <progress id="progress-bar" value="<%= @progress_ms %>" max="<%= @item.duration_ms %>" phx-hook="ProgressBar"><%= Tune.Duration.hms(@progress_ms) %></progress>
   <span class="total_duration"><%= Tune.Duration.hms(@item.duration_ms) %></span>
 </div>

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -52,12 +52,12 @@ msgid "Logged out"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:175
+#: lib/tune_web/live/explorer_live.ex:181
 msgid "No available devices"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:179
+#: lib/tune_web/live/explorer_live.ex:185
 msgid "Spotify error: %{reason}"
 msgstr ""
 

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -53,12 +53,12 @@ msgid "Logged out"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:175
+#: lib/tune_web/live/explorer_live.ex:181
 msgid "No available devices"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:179
+#: lib/tune_web/live/explorer_live.ex:185
 msgid "Spotify error: %{reason}"
 msgstr ""
 
@@ -92,7 +92,7 @@ msgstr ""
 msgid "Login via Spotify"
 msgstr ""
 
-#, elixir-format, fuzzy
+#, elixir-format
 #: lib/tune_web/live/explorer_live.html.leex:21
 msgid "Logout"
 msgstr ""


### PR DESCRIPTION
Closes #19

Adds support for seeking a specific position in the currently playing song by clicking on the progress bar.

The implementation leverages a custom Phoenix LiveView hook to calculate the desired position in milliseconds.
