### PR TITLE
Auto-terminate session worker after 30s inactivity

### DIFF
--- a/lib/tune/spotify/session.ex
+++ b/lib/tune/spotify/session.ex
@@ -2,8 +2,6 @@ defmodule Tune.Spotify.Session do
   @moduledoc """
   Defines a behaviour that can be used to model an active user session against the Spotify API.
   """
-  alias Phoenix.PubSub
-
   alias Tune.Duration
   alias Tune.Spotify.{HttpApi, Schema}
 
@@ -47,14 +45,6 @@ defmodule Tune.Spotify.Session do
   @callback get_player_token(id()) :: {:ok, player_token()} | {:error, term()}
   @callback transfer_playback(id(), Schema.Device.id()) :: :ok | {:error, term()}
   @callback set_volume(id(), Schema.Device.volume_percent()) :: :ok | {:error, term()}
-
-  @spec subscribe(id()) :: :ok | {:error, term()}
-  def subscribe(session_id) do
-    PubSub.subscribe(Tune.PubSub, session_id)
-  end
-
-  @spec broadcast(id(), message()) :: :ok | {:error, term()}
-  def broadcast(session_id, message) do
-    PubSub.broadcast(Tune.PubSub, session_id, message)
-  end
+  @callback subscribe(id()) :: :ok | {:error, term()}
+  @callback broadcast(id(), message()) :: :ok | {:error, term()}
 end

--- a/lib/tune_web/live/explorer_live.ex
+++ b/lib/tune_web/live/explorer_live.ex
@@ -57,7 +57,7 @@ defmodule TuneWeb.ExplorerLive do
           end
 
         if connected?(socket) do
-          Tune.Spotify.Session.subscribe(session_id)
+          spotify().subscribe(session_id)
         end
 
         {:ok,

--- a/test/tune_web/live/logged_in_test.exs
+++ b/test/tune_web/live/logged_in_test.exs
@@ -496,6 +496,7 @@ defmodule TuneWeb.LoggedInTest do
     |> expect(:get_profile, 3, fn ^session_id -> profile end)
     |> expect(:get_devices, 2, fn ^session_id -> [] end)
     |> expect(:get_player_token, 2, fn ^session_id -> {:ok, credentials.token} end)
+    |> expect(:subscribe, 1, fn ^session_id -> :ok end)
   end
 
   defp expect_nothing_playing(session_id) do


### PR DESCRIPTION
Closes #9 

Check every 30 seconds for inactivity, irrespectively of current state.

When timeout expires, if there are no subscribers the process gracefully
stops and it’s not restarted.