### PR TITLE
Handle free tier limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ auth (see `.env` for relevant environment variables).
   dormant client application, do a quick play/pause to wake it up and go back
   to Tune.
 
+  More information on the related [Spotify documentation
+  page](https://developer.spotify.com/documentation/web-api/guides/using-connect-web-api/#devices-not-appearing-on-device-list).
+
 # Credits
 
 - Mini player icons from [Bootstrap Icons](https://icons.getbootstrap.com/)

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -22,16 +22,18 @@ let spotifySDKReady = false;
 
 Hooks.ProgressBar = {
   mounted() {
-    this.el.addEventListener("click", (e) => {
-      const positionMs = Math.floor(
-        (e.target.max * e.offsetX) / e.target.offsetWidth
-      );
+    if (this.el.dataset.premium === "true") {
+      this.el.addEventListener("click", (e) => {
+        const positionMs = Math.floor(
+          (e.target.max * e.offsetX) / e.target.offsetWidth
+        );
 
-      // Optimistic update
-      this.el.value = positionMs;
+        // Optimistic update
+        this.el.value = positionMs;
 
-      this.pushEvent("seek", { position_ms: positionMs });
-    });
+        this.pushEvent("seek", { position_ms: positionMs });
+      });
+    }
   },
 };
 

--- a/lib/tune/spotify/http_api.ex
+++ b/lib/tune/spotify/http_api.ex
@@ -516,10 +516,11 @@ defmodule Tune.Spotify.HttpApi do
   end
 
   defp parse_profile(data) do
-    name = Map.get(data, "display_name")
-    avatar_url = get_in(data, ["images", Access.at(0), "url"])
-
-    %User{name: name, avatar_url: avatar_url}
+    %User{
+      name: Map.get(data, "display_name"),
+      avatar_url: get_in(data, ["images", Access.at(0), "url"]),
+      product: Map.get(data, "product")
+    }
   end
 
   defp handle_errors(response) do

--- a/lib/tune/spotify/schema/user.ex
+++ b/lib/tune/spotify/schema/user.ex
@@ -13,5 +13,5 @@ defmodule Tune.Spotify.Schema.User do
         }
 
   @spec premium?(t()) :: boolean()
-  def premium?(user), do: user.product == "premium"
+  def premium?(%__MODULE__{product: product}), do: product == "premium"
 end

--- a/lib/tune/spotify/schema/user.ex
+++ b/lib/tune/spotify/schema/user.ex
@@ -3,11 +3,15 @@ defmodule Tune.Spotify.Schema.User do
   Represents a Spotify user.
   """
 
-  @enforce_keys [:name, :avatar_url]
-  defstruct [:name, :avatar_url]
+  @enforce_keys [:name, :avatar_url, :product]
+  defstruct [:name, :avatar_url, :product]
 
   @type t :: %__MODULE__{
           name: String.t(),
-          avatar_url: String.t()
+          avatar_url: String.t(),
+          product: String.t()
         }
+
+  @spec premium?(t()) :: boolean()
+  def premium?(user), do: user.product == "premium"
 end

--- a/lib/tune_web/controllers/auth_controller.ex
+++ b/lib/tune_web/controllers/auth_controller.ex
@@ -7,8 +7,19 @@ defmodule TuneWeb.AuthController do
   plug Ueberauth
 
   def callback(%{assigns: %{ueberauth_auth: auth}} = conn, _params) do
+    premium? = get_in(auth.extra.raw_info, [:user, "product"]) == "premium"
+
+    conn =
+      if premium? do
+        put_flash(conn, :info, "Hello #{auth.info.name}!")
+      else
+        put_flash(conn, :warning, """
+        Hello #{auth.info.name}!
+        As you don't have a premium account, the embedded audio player and all audio controls are disabled.
+        """)
+      end
+
     conn
-    |> put_flash(:info, "Hello #{auth.info.name}!")
     |> put_session(:spotify_credentials, auth.credentials)
     |> put_session(:spotify_id, auth.info.nickname)
     |> configure_session(renew: true)

--- a/lib/tune_web/live/explorer_live.ex
+++ b/lib/tune_web/live/explorer_live.ex
@@ -39,7 +39,7 @@ defmodule TuneWeb.ExplorerLive do
 
   use TuneWeb, :live_view
 
-  alias Tune.Spotify.Schema.{Album, Player, Track}
+  alias Tune.Spotify.Schema.{Album, Player, Track, User}
 
   alias TuneWeb.{
     AlbumView,
@@ -59,7 +59,7 @@ defmodule TuneWeb.ExplorerLive do
     type: :track,
     results: %{items: [], total: 0},
     user: nil,
-    now_playing: %Tune.Spotify.Schema.Player{},
+    now_playing: %Player{},
     item: :not_fetched,
     per_page: 24,
     page: 1,
@@ -98,6 +98,7 @@ defmodule TuneWeb.ExplorerLive do
          |> assign(
            session_id: session_id,
            user: user,
+           premium?: User.premium?(user),
            now_playing: now_playing,
            devices: devices
          )}

--- a/lib/tune_web/live/explorer_live.html.leex
+++ b/lib/tune_web/live/explorer_live.html.leex
@@ -15,6 +15,10 @@
       phx-click="lv:clear-flash"
       phx-value-key="error"><%= live_flash(@flash, :error) %></a>
 
+    <a href="#" class="alert alert-warning" role="alert"
+      phx-click="lv:clear-flash"
+      phx-value-key="warning"><%= live_flash(@flash, :warning) %></a>
+
     <%= if @static_changed do %>
       <div class="alert alert-warning" role="alert">
         <%= gettext("The app has been updated.") %> <a href="#" onclick="window.location.reload()"><%= gettext("Click here to reload") %></a>.
@@ -49,7 +53,10 @@
           <p>Cannot display this item yet.</p>
         </div>
       <% end %>
-    <%= live_component @socket, MiniPlayerComponent, player_id: @player_id, now_playing: @now_playing, devices: @devices, id: :mini_player %>
-    <%= tag :div, id: "player", phx_hook: "AudioPlayer", data_token: @player_token, data_player_id: @player_id %>
+    <%= live_component @socket, MiniPlayerComponent, player_id: @player_id, premium?: @premium?, now_playing: @now_playing, devices: @devices, id: :mini_player %>
+    <%= if @premium? do %>
+      <script defer src="https://sdk.scdn.co/spotify-player.js"></script>
+      <%= tag :div, id: "player", phx_hook: "AudioPlayer", data_token: @player_token, data_player_id: @player_id %>
+    <% end %>
   </section>
 </main>

--- a/lib/tune_web/live/mini_player_component.html.leex
+++ b/lib/tune_web/live/mini_player_component.html.leex
@@ -1,18 +1,20 @@
 <div class="mini-player">
-  <div class="device">
-    <%= if Enum.empty?(@devices) do %>
-      <%= content_tag :p, gettext("No devices available"), class: "notice" %>
-    <% else %>
-      <%= render PlayerView, "icon_device.html", [] %>
-      <form action="#" method="get" phx-submit="transfer_playback">
-        <%= content_tag :label, gettext("Switch playback device"), for: "device", class: "visually-hidden" %>
-        <select name="device" id="device" phx-change="transfer_playback">
-          <%= devices_options(@devices, @player_id) %>
-        </select>
-        <%= content_tag :button, gettext("Select"), type: "submit" %>
-      </form>
-    <% end %>
-  </div>
+  <%= if @premium? do %>
+    <div class="device">
+      <%= if Enum.empty?(@devices) do %>
+        <%= content_tag :p, gettext("No devices available"), class: "notice" %>
+      <% else %>
+        <%= render PlayerView, "icon_device.html", [] %>
+        <form action="#" method="get" phx-submit="transfer_playback">
+          <%= content_tag :label, gettext("Switch playback device"), for: "device", class: "visually-hidden" %>
+          <select name="device" id="device" phx-change="transfer_playback">
+            <%= devices_options(@devices, @player_id) %>
+          </select>
+          <%= content_tag :button, gettext("Select"), type: "submit" %>
+        </form>
+      <% end %>
+    </div>
+  <% end %>
   <%= case @now_playing do %>
     <% %{status: :not_playing} -> %>
       <%= content_tag :p, gettext("Not playing") %>
@@ -21,7 +23,9 @@
         <%= img_tag thumbnail(item), alt: name(item) %>
       <% end %>
       <%= render PlayerView, "meta.html", item: item, socket: @socket %>
-      <%= live_component @socket, ProgressBarComponent, id: :progress_bar, progress_ms: progress_ms, total_duration_ms: item.duration_ms %>
-      <%= render PlayerView, "controls.html", status: status, device: device %>
+      <%= live_component @socket, ProgressBarComponent, id: :progress_bar, premium?: @premium?, progress_ms: progress_ms, total_duration_ms: item.duration_ms %>
+      <%= if @premium? do %>
+        <%= render PlayerView, "controls.html", status: status, device: device %>
+      <% end %>
   <% end %>
 </div>

--- a/lib/tune_web/live/progress_bar_component.html.leex
+++ b/lib/tune_web/live/progress_bar_component.html.leex
@@ -3,6 +3,7 @@
   <%= content_tag :label, gettext("Current track position"), for: "progress-bar", class: "visually-hidden" %>
   <progress
     id="progress-bar"
+    data-premium="<%= @premium? %>"
     data-test-control="progress"
     value="<%= @progress_ms %>"
     aria-valuenow="<%= @progress_ms %>"

--- a/lib/tune_web/templates/layout/root.html.leex
+++ b/lib/tune_web/templates/layout/root.html.leex
@@ -10,7 +10,6 @@
     <link phx-track-static rel="icon" type="image/svg+xml" color="#287989" href="<%= Routes.static_path(@conn, "/images/favicon.svg") %>">
     <link phx-track-static rel="alternate-icon" href="<%= Routes.static_path(@conn, "/favicon.ico") %>">
     <link phx-track-static rel="mask-icon" color="#287989" href="<%= Routes.static_path(@conn, "/images/favicon.svg") %>">
-    <script defer src="https://sdk.scdn.co/spotify-player.js"></script>
     <script defer phx-track-static type="text/javascript" src="<%= Routes.static_path(@conn, "/js/app.js") %>"></script>
   </head>
   <body onclick="">

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -42,22 +42,22 @@ msgstr[0] ""
 msgstr[1] ""
 
 #, elixir-format
-#: lib/tune_web/controllers/auth_controller.ex:20
+#: lib/tune_web/controllers/auth_controller.ex:31
 msgid "Error authenticating via Spotify"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/controllers/auth_controller.ex:31
+#: lib/tune_web/controllers/auth_controller.ex:42
 msgid "Logged out"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:403
+#: lib/tune_web/live/explorer_live.ex:404
 msgid "No available devices"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:407
+#: lib/tune_web/live/explorer_live.ex:408
 msgid "Spotify error: %{reason}"
 msgstr ""
 
@@ -97,7 +97,7 @@ msgid "No results"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/mini_player_component.html.leex:18
+#: lib/tune_web/live/mini_player_component.html.leex:20
 msgid "Not playing"
 msgstr ""
 
@@ -167,7 +167,7 @@ msgid "Go to Suggestions"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/mini_player_component.html.leex:8
+#: lib/tune_web/live/mini_player_component.html.leex:9
 msgid "Switch playback device"
 msgstr ""
 
@@ -220,7 +220,7 @@ msgid "this device"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/mini_player_component.html.leex:12
+#: lib/tune_web/live/mini_player_component.html.leex:13
 msgid "Select"
 msgstr ""
 
@@ -255,37 +255,37 @@ msgid "Open in YouTube"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.html.leex:20
+#: lib/tune_web/live/explorer_live.html.leex:24
 msgid "Click here to reload"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.html.leex:20
+#: lib/tune_web/live/explorer_live.html.leex:24
 msgid "The app has been updated."
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:356
+#: lib/tune_web/live/explorer_live.ex:357
 msgid "Album details"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:363
+#: lib/tune_web/live/explorer_live.ex:364
 msgid "Album details for %{name}"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:332
+#: lib/tune_web/live/explorer_live.ex:333
 msgid "Artist details"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:347
+#: lib/tune_web/live/explorer_live.ex:348
 msgid "Artist details for %{name}"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:390
+#: lib/tune_web/live/explorer_live.ex:391
 msgid "Episode details"
 msgstr ""
 
@@ -295,31 +295,31 @@ msgid "Home"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:285
+#: lib/tune_web/live/explorer_live.ex:286
 msgid "Search results"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:299
+#: lib/tune_web/live/explorer_live.ex:300
 msgid "Search results for %{q}"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:372
+#: lib/tune_web/live/explorer_live.ex:373
 msgid "Show details"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:381
+#: lib/tune_web/live/explorer_live.ex:382
 msgid "Show details for %{name}"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:255
+#: lib/tune_web/live/explorer_live.ex:256
 msgid "Suggestions"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/mini_player_component.html.leex:4
+#: lib/tune_web/live/mini_player_component.html.leex:5
 msgid "No devices available"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -43,22 +43,22 @@ msgstr[0] ""
 msgstr[1] ""
 
 #, elixir-format
-#: lib/tune_web/controllers/auth_controller.ex:20
+#: lib/tune_web/controllers/auth_controller.ex:31
 msgid "Error authenticating via Spotify"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/controllers/auth_controller.ex:31
+#: lib/tune_web/controllers/auth_controller.ex:42
 msgid "Logged out"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:403
+#: lib/tune_web/live/explorer_live.ex:404
 msgid "No available devices"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:407
+#: lib/tune_web/live/explorer_live.ex:408
 msgid "Spotify error: %{reason}"
 msgstr ""
 
@@ -98,7 +98,7 @@ msgid "No results"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/mini_player_component.html.leex:18
+#: lib/tune_web/live/mini_player_component.html.leex:20
 msgid "Not playing"
 msgstr ""
 
@@ -168,7 +168,7 @@ msgid "Go to Suggestions"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/mini_player_component.html.leex:8
+#: lib/tune_web/live/mini_player_component.html.leex:9
 msgid "Switch playback device"
 msgstr ""
 
@@ -221,7 +221,7 @@ msgid "this device"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/mini_player_component.html.leex:12
+#: lib/tune_web/live/mini_player_component.html.leex:13
 msgid "Select"
 msgstr ""
 
@@ -256,37 +256,37 @@ msgid "Open in YouTube"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.html.leex:20
+#: lib/tune_web/live/explorer_live.html.leex:24
 msgid "Click here to reload"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.html.leex:20
+#: lib/tune_web/live/explorer_live.html.leex:24
 msgid "The app has been updated."
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:356
+#: lib/tune_web/live/explorer_live.ex:357
 msgid "Album details"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:363
+#: lib/tune_web/live/explorer_live.ex:364
 msgid "Album details for %{name}"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:332
+#: lib/tune_web/live/explorer_live.ex:333
 msgid "Artist details"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:347
+#: lib/tune_web/live/explorer_live.ex:348
 msgid "Artist details for %{name}"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:390
+#: lib/tune_web/live/explorer_live.ex:391
 msgid "Episode details"
 msgstr ""
 
@@ -296,31 +296,31 @@ msgid "Home"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:285
+#: lib/tune_web/live/explorer_live.ex:286
 msgid "Search results"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:299
+#: lib/tune_web/live/explorer_live.ex:300
 msgid "Search results for %{q}"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:372
+#: lib/tune_web/live/explorer_live.ex:373
 msgid "Show details"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:381
+#: lib/tune_web/live/explorer_live.ex:382
 msgid "Show details for %{name}"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:255
+#: lib/tune_web/live/explorer_live.ex:256
 msgid "Suggestions"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/mini_player_component.html.leex:4
+#: lib/tune_web/live/mini_player_component.html.leex:5
 msgid "No devices available"
 msgstr ""

--- a/test/support/generators.ex
+++ b/test/support/generators.ex
@@ -259,10 +259,14 @@ defmodule Tune.Generators do
   end
 
   def profile do
-    tuple({name(), image_url()})
-    |> bind(fn {name, avatar_url} ->
-      constant(%User{name: name, avatar_url: avatar_url})
+    tuple({name(), image_url(), product()})
+    |> bind(fn {name, avatar_url, product} ->
+      constant(%User{name: name, avatar_url: avatar_url, product: product})
     end)
+  end
+
+  def product do
+    one_of([constant("premium")])
   end
 
   def album_type do


### PR DESCRIPTION
Closes #69

For free account users:

- Don't load the embedded audio SDK
- Display a post-login notice detailing the limitations of a free account
- Remove unusable UI controls: device switcher, controls, volume
- Disable position change via progress bar