### PR TITLE
Build and deploy docs

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -68,9 +68,11 @@ jobs:
       run: mix dialyzer --no-check
 
     - name: Build docs
+      if: github.ref == 'refs/heads/master'
       run: mix docs
 
     - name: Deploy dpcs
+      if: success() && github.ref == 'refs/heads/master'
       uses: JamesIves/github-pages-deploy-action@3.5.9
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -71,7 +71,7 @@ jobs:
       run: mix docs
 
     - name: Deploy dpcs
-      uses: JamesIves/github-pages-deploy-action@3
+      uses: JamesIves/github-pages-deploy-action@3.5.9
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BRANCH: gh-pages

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
 
     - name: Setup elixir
       uses: actions/setup-elixir@v1
@@ -64,3 +66,13 @@ jobs:
 
     - name: Run dialyzer
       run: mix dialyzer --no-check
+
+    - name: Build docs
+      run: mix docs
+
+    - name: Deploy dpcs
+        uses: JamesIves/github-pages-deploy-action@3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: docs

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -75,4 +75,4 @@ jobs:
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BRANCH: gh-pages
-        FOLDER: docs
+        FOLDER: doc

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -71,7 +71,7 @@ jobs:
       if: github.ref == 'refs/heads/master'
       run: mix docs
 
-    - name: Deploy dpcs
+    - name: Deploy docs
       if: success() && github.ref == 'refs/heads/master'
       uses: JamesIves/github-pages-deploy-action@3.5.9
       with:

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -71,8 +71,8 @@ jobs:
       run: mix docs
 
     - name: Deploy dpcs
-        uses: JamesIves/github-pages-deploy-action@3
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: docs
+      uses: JamesIves/github-pages-deploy-action@3
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        BRANCH: gh-pages
+        FOLDER: docs

--- a/README.md
+++ b/README.md
@@ -144,6 +144,11 @@ An instance of
 is mounted at `/dashboard`. In production, the endpoint is protected by basic
 auth (see `.env` for relevant environment variables).
 
+# Code documentation
+
+Available at <https://tune-docs.fullyforged.com>, gets automatically updated
+with every push on the `main` branch.
+
 # Limitations
 
 - If you use Tune in combination with official Spotify clients, you will notice


### PR DESCRIPTION
Uses https://github.com/marketplace/actions/deploy-to-github-pages to deploy mix docs to the `gh-pages` branch.

Before merging, the steps will be set to only run on `main`