### PR TITLE
Improve Spotify related behaviours

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ The `TuneWeb` namespace defines authentication endpoints and the main
 `LiveView` (`TuneWeb.ExplorerLive`) that powers the entire user interface.
 
 Tune assumes multiple browser sessions for the same user, which is why it
-defines a `Tune.Spotify.Session` behaviour with `Tune.Spotify.Session.Worker`
+defines a `Tune.Spotify.Session` behaviour with `Tune.Spotify.Session.HTTP`
 as its main runtime implementation.
 
 Each worker is responsible to proxy interaction with the Spotify API, 

--- a/config/config.exs
+++ b/config/config.exs
@@ -16,7 +16,8 @@ config :tune, TuneWeb.Endpoint,
   live_view: [signing_salt: "Op07Dt9x"]
 
 config :tune,
-  spotify: Tune.Spotify.Session.HTTP
+  spotify: Tune.Spotify.Session.HTTP,
+  spotify_client: Tune.Spotify.Client.HTTP
 
 # Configures Elixir's Logger
 config :logger, :console,

--- a/config/config.exs
+++ b/config/config.exs
@@ -16,7 +16,7 @@ config :tune, TuneWeb.Endpoint,
   live_view: [signing_salt: "Op07Dt9x"]
 
 config :tune,
-  spotify: Tune.Spotify.Session.Worker
+  spotify: Tune.Spotify.Session.HTTP
 
 # Configures Elixir's Logger
 config :logger, :console,

--- a/config/config.exs
+++ b/config/config.exs
@@ -16,7 +16,7 @@ config :tune, TuneWeb.Endpoint,
   live_view: [signing_salt: "Op07Dt9x"]
 
 config :tune,
-  spotify: Tune.Spotify.Session.HTTP,
+  spotify_session: Tune.Spotify.Session.HTTP,
   spotify_client: Tune.Spotify.Client.HTTP
 
 # Configures Elixir's Logger

--- a/config/test.exs
+++ b/config/test.exs
@@ -7,7 +7,7 @@ config :tune, TuneWeb.Endpoint,
   server: false
 
 config :tune,
-  spotify: Tune.Spotify.Session.Mock,
+  spotify_session: Tune.Spotify.Session.Mock,
   spotify_client: Tune.Spotify.Client.Mock
 
 # Print only warnings and errors during test

--- a/config/test.exs
+++ b/config/test.exs
@@ -7,7 +7,7 @@ config :tune, TuneWeb.Endpoint,
   server: false
 
 config :tune,
-  spotify: Tune.Spotify.SessionMock,
+  spotify: Tune.Spotify.Session.Mock,
   spotify_client: Tune.Spotify.Client.Mock
 
 # Print only warnings and errors during test

--- a/config/test.exs
+++ b/config/test.exs
@@ -7,7 +7,8 @@ config :tune, TuneWeb.Endpoint,
   server: false
 
 config :tune,
-  spotify: Tune.Spotify.SessionMock
+  spotify: Tune.Spotify.SessionMock,
+  spotify_client: Tune.Spotify.Client.Mock
 
 # Print only warnings and errors during test
 config :logger, level: :warn

--- a/lib/tune/auth.ex
+++ b/lib/tune/auth.ex
@@ -8,9 +8,9 @@ defmodule Tune.Auth do
 
   @spec load_user(http_session()) :: {:authenticated, Session.id(), User.t()} | {:error, term()}
   def load_user(%{"spotify_id" => session_id, "spotify_credentials" => credentials}) do
-    case spotify().setup(session_id, credentials) do
+    case spotify_session().setup(session_id, credentials) do
       :ok ->
-        {:authenticated, session_id, spotify().get_profile(session_id)}
+        {:authenticated, session_id, spotify_session().get_profile(session_id)}
 
       error ->
         error
@@ -19,5 +19,5 @@ defmodule Tune.Auth do
 
   def load_user(_session), do: {:error, :not_authenticated}
 
-  defp spotify, do: Application.get_env(:tune, :spotify)
+  defp spotify_session, do: Application.get_env(:tune, :spotify_session)
 end

--- a/lib/tune/spotify/client.ex
+++ b/lib/tune/spotify/client.ex
@@ -1,0 +1,73 @@
+defmodule Tune.Spotify.Client do
+  @moduledoc """
+  Defines a behaviour that can be used to model a Spotify API client.
+
+  For a working implementation, see `Tune.Spotify.Client.HTTP`.
+  """
+
+  alias Tune.Duration
+
+  alias Tune.Spotify.Schema.{
+    Album,
+    Artist,
+    Device,
+    Episode,
+    Player,
+    Playlist,
+    Show,
+    Track,
+    User
+  }
+
+  alias Ueberauth.Auth.Credentials
+
+  @type token :: String.t()
+  @type q :: String.t()
+  @type item_type :: :album | :artist | :playlist | :track | :show | :episode | :playlist
+  @type pagination_option :: {:limit, pos_integer()} | {:offset, pos_integer()}
+  @type pagination_options :: [pagination_option()]
+  @type search_options :: [{:types, [item_type()]} | pagination_option()]
+  @type search_results :: %{
+          optional(item_type()) => %{
+            total: pos_integer(),
+            items:
+              [Artist.t()]
+              | [Album.t()]
+              | [Track.t()]
+              | [Show.t()]
+              | [Episode.t()]
+              | [Playlist.t()]
+          }
+        }
+  @type top_tracks_options :: [{:time_range, String.t()} | pagination_option()]
+
+  ## AUTH/PROFILE
+  @callback get_profile(token()) :: {:ok, User.t()} | {:error, term()}
+  @callback get_token(token()) :: {:ok, Credentials.t()} | {:error, term()}
+
+  ## PLAYER
+  @callback get_devices(token()) :: {:ok, [Device.t()]} | {:error, term()}
+  @callback next(token()) :: :ok | {:error, term()}
+  @callback now_playing(token()) :: {:ok, Player.t()} | {:error, term()}
+  @callback pause(token()) :: :ok | {:error, term()}
+  @callback play(token()) :: :ok | {:error, term()}
+  @callback play(token(), String.t()) :: :ok | {:error, term()}
+  @callback play(token(), String.t(), String.t()) :: :ok | {:error, term()}
+  @callback prev(token()) :: :ok | {:error, term()}
+  @callback seek(token(), Duration.milliseconds()) :: :ok | {:error, term()}
+  @callback set_volume(token(), Device.volume_percent()) :: :ok | {:error, term()}
+  @callback transfer_playback(token(), Device.id()) :: :ok | {:error, term()}
+
+  ## CONTENT
+  @callback get_album(token(), String.t()) :: {:ok, Album.t()} | {:error, term()}
+  @callback get_artist(token(), String.t()) :: {:ok, Artist.t()} | {:error, term()}
+  @callback get_artist_albums(token(), String.t(), pagination_options()) ::
+              {:ok, %{albums: [Album.t()], total: pos_integer()}} | {:error, term()}
+  @callback get_episodes(token(), String.t()) :: {:ok, [Episode.t()]} | {:error, term()}
+  @callback get_playlist(token(), String.t()) :: {:ok, map()} | {:error, term()}
+  @callback get_recommendations_from_artists(token(), [Artist.id()]) ::
+              {:ok, [Track.t()]} | {:error, term()}
+  @callback get_show(token(), String.t()) :: {:ok, Show.t()} | {:error, term()}
+  @callback search(token(), q(), search_options()) :: {:ok, search_results()} | {:error, term()}
+  @callback top_tracks(token(), top_tracks_options()) :: {:ok, [Track.t()]} | {:error, term()}
+end

--- a/lib/tune/spotify/client/http.ex
+++ b/lib/tune/spotify/client/http.ex
@@ -1,4 +1,4 @@
-defmodule Tune.Spotify.HttpApi do
+defmodule Tune.Spotify.Client.HTTP do
   @moduledoc false
   alias Tune.Spotify.Schema.{
     Album,

--- a/lib/tune/spotify/client/http.ex
+++ b/lib/tune/spotify/client/http.ex
@@ -1,5 +1,8 @@
 defmodule Tune.Spotify.Client.HTTP do
   @moduledoc false
+
+  @behaviour Tune.Spotify.Client
+
   alias Tune.Spotify.Schema.{
     Album,
     Artist,
@@ -14,7 +17,6 @@ defmodule Tune.Spotify.Client.HTTP do
   }
 
   alias Tune.Spotify.Auth
-  alias Tune.Duration
   alias Ueberauth.Auth.Credentials
 
   require Logger
@@ -32,27 +34,11 @@ defmodule Tune.Spotify.Client.HTTP do
   @default_limit 20
   @default_offset 0
 
-  @type token :: String.t()
-  @type q :: String.t()
-  @type item_type :: :album | :artist | :playlist | :track | :show | :episode | :playlist
-  @type pagination_option :: {:limit, pos_integer()} | {:offset, pos_integer()}
-  @type pagination_options :: [pagination_option()]
-  @type search_options :: [{:types, [item_type()]} | pagination_option()]
-  @type search_results :: %{
-          optional(item_type()) => %{
-            total: pos_integer(),
-            items:
-              [Artist.t()]
-              | [Album.t()]
-              | [Track.t()]
-              | [Show.t()]
-              | [Episode.t()]
-              | [Playlist.t()]
-          }
-        }
-  @type top_tracks_options :: [{:time_range, String.t()} | pagination_option()]
+  ################################################################################
+  ################################ AUTH/PROFILE ##################################
+  ################################################################################
 
-  @spec get_profile(token()) :: {:ok, User.t()} | {:error, term()}
+  @impl true
   def get_profile(token) do
     case json_get(@base_url <> "/me", auth_headers(token)) do
       {:ok, %{status: 200} = response} ->
@@ -68,142 +54,7 @@ defmodule Tune.Spotify.Client.HTTP do
     end
   end
 
-  @spec now_playing(token()) :: {:ok, Player.t()} | {:error, term()}
-  def now_playing(token) do
-    case json_get(@base_url <> "/me/player?additional_types=episode", auth_headers(token)) do
-      {:ok, %{status: 204}} ->
-        {:ok, %Player{}}
-
-      {:ok, %{status: 200} = response} ->
-        {:ok,
-         response.body
-         |> Jason.decode!()
-         |> parse_now_playing()}
-
-      other_response ->
-        handle_errors(other_response)
-    end
-  end
-
-  @spec play(token()) :: :ok | {:error, term()}
-  def play(token) do
-    case json_put(@base_url <> "/me/player/play", %{}, auth_headers(token)) do
-      {:ok, %{status: 204}} ->
-        :ok
-
-      other_response ->
-        handle_errors(other_response)
-    end
-  end
-
-  @spec play(token(), String.t()) :: :ok | {:error, term()}
-  def play(token, uri) do
-    payload =
-      if uri =~ "track" or uri =~ "episode" do
-        %{uris: [uri]}
-      else
-        %{context_uri: uri}
-      end
-
-    case json_put(@base_url <> "/me/player/play", payload, auth_headers(token)) do
-      {:ok, %{status: 204}} ->
-        :ok
-
-      other_response ->
-        handle_errors(other_response)
-    end
-  end
-
-  @spec play(token(), String.t(), String.t()) :: :ok | {:error, term()}
-  def play(token, uri, context_uri) do
-    payload = %{
-      context_uri: context_uri,
-      offset: %{
-        uri: uri
-      }
-    }
-
-    case json_put(@base_url <> "/me/player/play", payload, auth_headers(token)) do
-      {:ok, %{status: 204}} ->
-        :ok
-
-      other_response ->
-        handle_errors(other_response)
-    end
-  end
-
-  @spec pause(token()) :: :ok | {:error, term()}
-  def pause(token) do
-    case json_put(@base_url <> "/me/player/pause", %{}, auth_headers(token)) do
-      {:ok, %{status: 204}} ->
-        :ok
-
-      other_response ->
-        handle_errors(other_response)
-    end
-  end
-
-  @spec next(token()) :: :ok | {:error, term()}
-  def next(token) do
-    case post(@base_url <> "/me/player/next", <<>>, auth_headers(token)) do
-      {:ok, %{status: 204}} ->
-        :ok
-
-      other_response ->
-        handle_errors(other_response)
-    end
-  end
-
-  @spec prev(token()) :: :ok | {:error, term()}
-  def prev(token) do
-    case post(@base_url <> "/me/player/previous", <<>>, auth_headers(token)) do
-      {:ok, %{status: 204}} ->
-        :ok
-
-      other_response ->
-        handle_errors(other_response)
-    end
-  end
-
-  @spec seek(token(), Duration.milliseconds()) :: :ok | {:error, term()}
-  def seek(token, position_ms) do
-    params = %{
-      position_ms: position_ms
-    }
-
-    case put(
-           @base_url <> "/me/player/seek?" <> URI.encode_query(params),
-           <<>>,
-           auth_headers(token)
-         ) do
-      {:ok, %{status: 204}} ->
-        :ok
-
-      other_response ->
-        handle_errors(other_response)
-    end
-  end
-
-  @spec set_volume(token(), Device.volume_percent()) :: :ok | {:error, term()}
-  def set_volume(token, volume_percent) do
-    params = %{
-      volume_percent: volume_percent
-    }
-
-    case put(
-           @base_url <> "/me/player/volume?" <> URI.encode_query(params),
-           <<>>,
-           auth_headers(token)
-         ) do
-      {:ok, %{status: 204}} ->
-        :ok
-
-      other_response ->
-        handle_errors(other_response)
-    end
-  end
-
-  @spec get_token(token()) :: {:ok, Credentials.t()} | {:error, term()}
+  @impl true
   def get_token(refresh_token) do
     headers = [
       {"Authorization", "Basic #{Auth.base64_encoded_credentials()}"}
@@ -227,9 +78,349 @@ defmodule Tune.Spotify.Client.HTTP do
     end
   end
 
+  ################################################################################
+  #################################### PLAYER ####################################
+  ################################################################################
+
+  @impl true
+  def get_devices(token) do
+    case json_get(@base_url <> "/me/player/devices", auth_headers(token)) do
+      {:ok, %{status: 200} = response} ->
+        devices =
+          response.body
+          |> Jason.decode!()
+          |> Map.get("devices")
+          |> Enum.map(&parse_device/1)
+
+        {:ok, devices}
+
+      other_response ->
+        handle_errors(other_response)
+    end
+  end
+
+  @impl true
+  def next(token) do
+    case post(@base_url <> "/me/player/next", <<>>, auth_headers(token)) do
+      {:ok, %{status: 204}} ->
+        :ok
+
+      other_response ->
+        handle_errors(other_response)
+    end
+  end
+
+  @impl true
+  def now_playing(token) do
+    case json_get(@base_url <> "/me/player?additional_types=episode", auth_headers(token)) do
+      {:ok, %{status: 204}} ->
+        {:ok, %Player{}}
+
+      {:ok, %{status: 200} = response} ->
+        {:ok,
+         response.body
+         |> Jason.decode!()
+         |> parse_now_playing()}
+
+      other_response ->
+        handle_errors(other_response)
+    end
+  end
+
+  @impl true
+  def pause(token) do
+    case json_put(@base_url <> "/me/player/pause", %{}, auth_headers(token)) do
+      {:ok, %{status: 204}} ->
+        :ok
+
+      other_response ->
+        handle_errors(other_response)
+    end
+  end
+
+  @impl true
+  def play(token) do
+    case json_put(@base_url <> "/me/player/play", %{}, auth_headers(token)) do
+      {:ok, %{status: 204}} ->
+        :ok
+
+      other_response ->
+        handle_errors(other_response)
+    end
+  end
+
+  @impl true
+  def play(token, uri) do
+    payload =
+      if uri =~ "track" or uri =~ "episode" do
+        %{uris: [uri]}
+      else
+        %{context_uri: uri}
+      end
+
+    case json_put(@base_url <> "/me/player/play", payload, auth_headers(token)) do
+      {:ok, %{status: 204}} ->
+        :ok
+
+      other_response ->
+        handle_errors(other_response)
+    end
+  end
+
+  @impl true
+  def play(token, uri, context_uri) do
+    payload = %{
+      context_uri: context_uri,
+      offset: %{
+        uri: uri
+      }
+    }
+
+    case json_put(@base_url <> "/me/player/play", payload, auth_headers(token)) do
+      {:ok, %{status: 204}} ->
+        :ok
+
+      other_response ->
+        handle_errors(other_response)
+    end
+  end
+
+  @impl true
+  def prev(token) do
+    case post(@base_url <> "/me/player/previous", <<>>, auth_headers(token)) do
+      {:ok, %{status: 204}} ->
+        :ok
+
+      other_response ->
+        handle_errors(other_response)
+    end
+  end
+
+  @impl true
+  def seek(token, position_ms) do
+    params = %{
+      position_ms: position_ms
+    }
+
+    case put(
+           @base_url <> "/me/player/seek?" <> URI.encode_query(params),
+           <<>>,
+           auth_headers(token)
+         ) do
+      {:ok, %{status: 204}} ->
+        :ok
+
+      other_response ->
+        handle_errors(other_response)
+    end
+  end
+
+  @impl true
+  def set_volume(token, volume_percent) do
+    params = %{
+      volume_percent: volume_percent
+    }
+
+    case put(
+           @base_url <> "/me/player/volume?" <> URI.encode_query(params),
+           <<>>,
+           auth_headers(token)
+         ) do
+      {:ok, %{status: 204}} ->
+        :ok
+
+      other_response ->
+        handle_errors(other_response)
+    end
+  end
+
+  @impl true
+  def transfer_playback(token, device_id) do
+    params = %{
+      device_ids: [device_id]
+    }
+
+    case json_put(@base_url <> "/me/player", params, auth_headers(token)) do
+      {:ok, %{status: 204}} ->
+        :ok
+
+      other_response ->
+        handle_errors(other_response)
+    end
+  end
+
+  ################################################################################
+  ################################### CONTENT ####################################
+  ################################################################################
+
+  @impl true
+  def get_album(token, album_id) do
+    params = %{
+      market: "from_token"
+    }
+
+    case json_get(
+           @base_url <> "/albums/" <> album_id <> "?" <> URI.encode_query(params),
+           auth_headers(token)
+         ) do
+      {:ok, %{status: 200} = response} ->
+        album =
+          response.body
+          |> Jason.decode!()
+          |> parse_album()
+
+        {:ok, album}
+
+      other_response ->
+        handle_errors(other_response)
+    end
+  end
+
+  @impl true
+  def get_artist(token, artist_id) do
+    case json_get(
+           @base_url <> "/artists/" <> artist_id,
+           auth_headers(token)
+         ) do
+      {:ok, %{status: 200} = response} ->
+        artist =
+          response.body
+          |> Jason.decode!()
+          |> parse_artist()
+
+        {:ok, artist}
+
+      other_response ->
+        handle_errors(other_response)
+    end
+  end
+
+  @impl true
+  def get_artist_albums(token, artist_id, opts) do
+    limit = Keyword.get(opts, :limit, @default_limit)
+    offset = Keyword.get(opts, :offset, @default_offset)
+
+    params = %{
+      market: "from_token",
+      limit: limit,
+      offset: offset
+    }
+
+    case json_get(
+           @base_url <> "/artists/" <> artist_id <> "/albums" <> "?" <> URI.encode_query(params),
+           auth_headers(token)
+         ) do
+      {:ok, %{status: 200} = response} ->
+        albums =
+          response.body
+          |> Jason.decode!()
+          |> parse_artist_albums()
+
+        {:ok, albums}
+
+      other_response ->
+        handle_errors(other_response)
+    end
+  end
+
+  @impl true
+  def get_episodes(token, show_id) do
+    params = %{
+      market: "from_token"
+    }
+
+    case json_get(
+           @base_url <> "/shows/" <> show_id <> "/episodes" <> "?" <> URI.encode_query(params),
+           auth_headers(token)
+         ) do
+      {:ok, %{status: 200} = response} ->
+        episodes =
+          response.body
+          |> Jason.decode!()
+          |> Map.get("items")
+          |> Enum.map(&parse_episode/1)
+
+        {:ok, episodes}
+
+      other_response ->
+        handle_errors(other_response)
+    end
+  end
+
+  @impl true
+  def get_playlist(token, playlist_id) do
+    params = %{
+      market: "from_token"
+    }
+
+    case json_get(
+           @base_url <> "/playlists/" <> playlist_id <> "?" <> URI.encode_query(params),
+           auth_headers(token)
+         ) do
+      {:ok, %{status: 200} = response} ->
+        playlist =
+          response.body
+          |> Jason.decode!()
+          |> parse_playlist()
+
+        {:ok, playlist}
+
+      other_response ->
+        handle_errors(other_response)
+    end
+  end
+
+  @impl true
+  def get_recommendations_from_artists(token, artist_ids) do
+    params = %{
+      seed_artists: Enum.join(artist_ids, ","),
+      market: "from_token"
+    }
+
+    case json_get(
+           @base_url <> "/recommendations" <> "?" <> URI.encode_query(params),
+           auth_headers(token)
+         ) do
+      {:ok, %{status: 200} = response} ->
+        tracks =
+          response.body
+          |> Jason.decode!()
+          |> Map.get("tracks")
+          |> Enum.map(&parse_track/1)
+
+        {:ok, tracks}
+
+      other_response ->
+        handle_errors(other_response)
+    end
+  end
+
+  @impl true
+  def get_show(token, show_id) do
+    params = %{
+      market: "from_token"
+    }
+
+    case json_get(
+           @base_url <> "/shows/" <> show_id <> "?" <> URI.encode_query(params),
+           auth_headers(token)
+         ) do
+      {:ok, %{status: 200} = response} ->
+        show =
+          response.body
+          |> Jason.decode!()
+          |> parse_show()
+
+        {:ok, show}
+
+      other_response ->
+        handle_errors(other_response)
+    end
+  end
+
   @default_types [:track]
 
-  @spec search(token(), q(), search_options()) :: {:ok, search_results()} | {:error, term()}
+  @impl true
   def search(token, q, opts) do
     limit = Keyword.get(opts, :limit, @default_limit)
     offset = Keyword.get(opts, :offset, @default_offset)
@@ -258,7 +449,7 @@ defmodule Tune.Spotify.Client.HTTP do
   end
 
   @default_time_range "medium_term"
-  @spec top_tracks(token(), top_tracks_options()) :: {:ok, [Track.t()]} | {:error, term()}
+  @impl true
   def top_tracks(token, opts) do
     limit = Keyword.get(opts, :limit, @default_limit)
     offset = Keyword.get(opts, :offset, @default_offset)
@@ -279,205 +470,6 @@ defmodule Tune.Spotify.Client.HTTP do
           |> Enum.map(&parse_track/1)
 
         {:ok, results}
-
-      other_response ->
-        handle_errors(other_response)
-    end
-  end
-
-  @spec get_album(token(), String.t()) :: {:ok, Album.t()} | {:error, term()}
-  def get_album(token, album_id) do
-    params = %{
-      market: "from_token"
-    }
-
-    case json_get(
-           @base_url <> "/albums/" <> album_id <> "?" <> URI.encode_query(params),
-           auth_headers(token)
-         ) do
-      {:ok, %{status: 200} = response} ->
-        album =
-          response.body
-          |> Jason.decode!()
-          |> parse_album()
-
-        {:ok, album}
-
-      other_response ->
-        handle_errors(other_response)
-    end
-  end
-
-  @spec get_artist(token(), String.t()) :: {:ok, Artist.t()} | {:error, term()}
-  def get_artist(token, artist_id) do
-    case json_get(
-           @base_url <> "/artists/" <> artist_id,
-           auth_headers(token)
-         ) do
-      {:ok, %{status: 200} = response} ->
-        artist =
-          response.body
-          |> Jason.decode!()
-          |> parse_artist()
-
-        {:ok, artist}
-
-      other_response ->
-        handle_errors(other_response)
-    end
-  end
-
-  @spec get_artist_albums(token(), String.t(), pagination_options()) ::
-          {:ok, %{albums: [Album.t()], total: pos_integer()}} | {:error, term()}
-  def get_artist_albums(token, artist_id, opts) do
-    limit = Keyword.get(opts, :limit, @default_limit)
-    offset = Keyword.get(opts, :offset, @default_offset)
-
-    params = %{
-      market: "from_token",
-      limit: limit,
-      offset: offset
-    }
-
-    case json_get(
-           @base_url <> "/artists/" <> artist_id <> "/albums" <> "?" <> URI.encode_query(params),
-           auth_headers(token)
-         ) do
-      {:ok, %{status: 200} = response} ->
-        albums =
-          response.body
-          |> Jason.decode!()
-          |> parse_artist_albums()
-
-        {:ok, albums}
-
-      other_response ->
-        handle_errors(other_response)
-    end
-  end
-
-  @spec get_show(token(), String.t()) :: {:ok, Show.t()} | {:error, term()}
-  def get_show(token, show_id) do
-    params = %{
-      market: "from_token"
-    }
-
-    case json_get(
-           @base_url <> "/shows/" <> show_id <> "?" <> URI.encode_query(params),
-           auth_headers(token)
-         ) do
-      {:ok, %{status: 200} = response} ->
-        show =
-          response.body
-          |> Jason.decode!()
-          |> parse_show()
-
-        {:ok, show}
-
-      other_response ->
-        handle_errors(other_response)
-    end
-  end
-
-  @spec get_episodes(token(), String.t()) :: {:ok, [Episode.t()]} | {:error, term()}
-  def get_episodes(token, show_id) do
-    params = %{
-      market: "from_token"
-    }
-
-    case json_get(
-           @base_url <> "/shows/" <> show_id <> "/episodes" <> "?" <> URI.encode_query(params),
-           auth_headers(token)
-         ) do
-      {:ok, %{status: 200} = response} ->
-        episodes =
-          response.body
-          |> Jason.decode!()
-          |> Map.get("items")
-          |> Enum.map(&parse_episode/1)
-
-        {:ok, episodes}
-
-      other_response ->
-        handle_errors(other_response)
-    end
-  end
-
-  @spec get_playlist(token(), String.t()) :: {:ok, map()} | {:error, term()}
-  def get_playlist(token, playlist_id) do
-    params = %{
-      market: "from_token"
-    }
-
-    case json_get(
-           @base_url <> "/playlists/" <> playlist_id <> "?" <> URI.encode_query(params),
-           auth_headers(token)
-         ) do
-      {:ok, %{status: 200} = response} ->
-        playlist =
-          response.body
-          |> Jason.decode!()
-          |> parse_playlist()
-
-        {:ok, playlist}
-
-      other_response ->
-        handle_errors(other_response)
-    end
-  end
-
-  @spec get_devices(token()) :: {:ok, [Device.t()]} | {:error, term()}
-  def get_devices(token) do
-    case json_get(@base_url <> "/me/player/devices", auth_headers(token)) do
-      {:ok, %{status: 200} = response} ->
-        devices =
-          response.body
-          |> Jason.decode!()
-          |> Map.get("devices")
-          |> Enum.map(&parse_device/1)
-
-        {:ok, devices}
-
-      other_response ->
-        handle_errors(other_response)
-    end
-  end
-
-  @spec transfer_playback(token(), Device.id()) :: :ok | {:error, term()}
-  def transfer_playback(token, device_id) do
-    params = %{
-      device_ids: [device_id]
-    }
-
-    case json_put(@base_url <> "/me/player", params, auth_headers(token)) do
-      {:ok, %{status: 204}} ->
-        :ok
-
-      other_response ->
-        handle_errors(other_response)
-    end
-  end
-
-  @spec get_recommendations_from_artists(token(), [Artist.id()]) ::
-          {:ok, [Track.t()]} | {:error, term()}
-  def get_recommendations_from_artists(token, artist_ids) do
-    params = %{
-      seed_artists: Enum.join(artist_ids, ","),
-      market: "from_token"
-    }
-
-    case json_get(
-           @base_url <> "/recommendations" <> "?" <> URI.encode_query(params),
-           auth_headers(token)
-         ) do
-      {:ok, %{status: 200} = response} ->
-        tracks =
-          response.body
-          |> Jason.decode!()
-          |> Map.get("tracks")
-          |> Enum.map(&parse_track/1)
-
-        {:ok, tracks}
 
       other_response ->
         handle_errors(other_response)

--- a/lib/tune/spotify/client/http.ex
+++ b/lib/tune/spotify/client/http.ex
@@ -1,5 +1,10 @@
 defmodule Tune.Spotify.Client.HTTP do
-  @moduledoc false
+  @moduledoc """
+  This module implements the `Tune.Spotify.Client` behaviour and interacts with
+  the actual Spotify API.
+
+  Reference docs are available at: <https://developer.spotify.com/documentation/web-api/>
+  """
 
   @behaviour Tune.Spotify.Client
 

--- a/lib/tune/spotify/session.ex
+++ b/lib/tune/spotify/session.ex
@@ -13,7 +13,7 @@ defmodule Tune.Spotify.Session do
   Two extra functions, `c:subscribe/1` and `c:broadcast/2`, are used to define
   the mechanism used to notify other processes of changes in the session state.
 
-  For a working implementation, see `Tune.Spotify.Session.Worker`.
+  For a working implementation, see `Tune.Spotify.Session.HTTP`.
   """
   alias Tune.Duration
   alias Tune.Spotify.{HttpApi, Schema}

--- a/lib/tune/spotify/session.ex
+++ b/lib/tune/spotify/session.ex
@@ -16,7 +16,7 @@ defmodule Tune.Spotify.Session do
   For a working implementation, see `Tune.Spotify.Session.HTTP`.
   """
   alias Tune.Duration
-  alias Tune.Spotify.{HttpApi, Schema}
+  alias Tune.Spotify.{Client, Schema}
 
   @type id :: String.t()
   @type credentials :: Ueberauth.Auth.Credentials.t()
@@ -40,13 +40,13 @@ defmodule Tune.Spotify.Session do
   @callback next(id()) :: :ok | {:error, term()}
   @callback seek(id(), Duration.milliseconds()) :: :ok | {:error, term()}
   @callback prev(id()) :: :ok | {:error, term()}
-  @callback search(id(), HttpApi.q(), HttpApi.search_options()) ::
-              {:ok, HttpApi.search_results()} | {:error, term()}
-  @callback top_tracks(id(), HttpApi.top_tracks_options()) ::
+  @callback search(id(), Client.q(), Client.search_options()) ::
+              {:ok, Client.search_results()} | {:error, term()}
+  @callback top_tracks(id(), Client.top_tracks_options()) ::
               {:ok, [Schema.Track.t()]} | {:error, term()}
   @callback get_album(id(), item_id()) :: {:ok, Schema.Album.t()} | {:error, term()}
   @callback get_artist(id(), item_id()) :: {:ok, Schema.Artist.t()} | {:error, term()}
-  @callback get_artist_albums(id(), item_id(), HttpApi.pagination_options()) ::
+  @callback get_artist_albums(id(), item_id(), Client.pagination_options()) ::
               {:ok, %{albums: [Schema.Album.t()], total: pos_integer()}} | {:error, term()}
   @callback get_show(id(), item_id()) :: {:ok, Schema.Show.t()} | {:error, term()}
   @callback get_episodes(id(), item_id()) :: {:ok, [Schema.Episode.t()]} | {:error, term()}

--- a/lib/tune/spotify/session/http.ex
+++ b/lib/tune/spotify/session/http.ex
@@ -1,11 +1,11 @@
-defmodule Tune.Spotify.Session.Worker do
+defmodule Tune.Spotify.Session.HTTP do
   @moduledoc """
-  This module implements a worker mapped to a user session, wrapping
+  This module implements a state machine mapped to a user session, wrapping
   interaction with the Spotify API.
 
   ## General structure
 
-  The worker implements the `Tune.Spotify.Session` behaviour for its public API
+  The state machine implements the `Tune.Spotify.Session` behaviour for its public API
   and uses `GenStateMachine` to model its lifecycle.
 
   If you're not familiar with the `gen_statem` behaviour (which powers
@@ -63,7 +63,7 @@ defmodule Tune.Spotify.Session.Worker do
   ## Data lifecycle
 
   Aside from acting as an API client for on-demand operations (e.g. search,
-  play/pause, etc.), the worker also regularly polls the Spotify API for
+  play/pause, etc.), the state machine also regularly polls the Spotify API for
   current player status and connected devices. Both pieces of information are
   kept in the state machine data for fast read and corresponding events are
   broadcasted when they change.
@@ -83,17 +83,17 @@ defmodule Tune.Spotify.Session.Worker do
   Multiple processes are able to subscribe to the events keyed by the session id.
 
   Broadcast and subscribe are implemented via `Phoenix.PubSub`, however the
-  Worker maintains its own set of monitored processes subscribed to the session
+  state machine maintains its own set of monitored processes subscribed to the session
   id.
 
   Subscription tracking is necessary to implementing automatic termination of a
-  worker after a period of inactivity. Without that, the worker would
+  state machine after a period of inactivity. Without that, the state machine would
   indefinitely poll the Spotify API, even when no client is interested into the
   topic, until a crash error or a node reboot.
 
-  Every 30 seconds, the worker fires a named `timeout` event, checking if
+  Every 30 seconds, the state machine fires a named `timeout` event, checking if
   there's any subscribed process. If not, it terminates. Subscribed processes
-  are monitored, so when they terminate, their exit is handled by the worker,
+  are monitored, so when they terminate, their exit is handled by the state machine,
   which removes them from its data.
 
   Usage of named `timeout` events is necessary, as they're guaranteed to fire

--- a/lib/tune/spotify/session/http.ex
+++ b/lib/tune/spotify/session/http.ex
@@ -103,7 +103,7 @@ defmodule Tune.Spotify.Session.HTTP do
   use GenStateMachine, restart: :transient
   @behaviour Tune.Spotify.Session
 
-  alias Tune.Spotify.{HttpApi, Session, SessionRegistry}
+  alias Tune.Spotify.{Session, SessionRegistry}
   alias Phoenix.PubSub
 
   defstruct session_id: nil,
@@ -272,7 +272,7 @@ defmodule Tune.Spotify.Session.HTTP do
   @impl true
   def handle_event(event_type, :authenticate, :not_authenticated, data)
       when event_type in [:internal, :state_timeout] do
-    case HttpApi.get_profile(data.credentials.token) do
+    case spotify_client().get_profile(data.credentials.token) do
       {:ok, user} ->
         data = %{data | user: user}
 
@@ -303,7 +303,7 @@ defmodule Tune.Spotify.Session.HTTP do
 
   def handle_event(event_type, :refresh, :expired, data)
       when event_type in [:internal, :state_timeout] do
-    case HttpApi.get_token(data.credentials.refresh_token) do
+    case spotify_client().get_token(data.credentials.refresh_token) do
       {:ok, new_credentials} ->
         data = %{data | credentials: new_credentials}
         action = {:next_event, :internal, :authenticate}
@@ -320,7 +320,7 @@ defmodule Tune.Spotify.Session.HTTP do
   end
 
   def handle_event(:internal, :get_now_playing, :authenticated, data) do
-    case HttpApi.now_playing(data.credentials.token) do
+    case spotify_client().now_playing(data.credentials.token) do
       {:error, :invalid_token} ->
         {:stop, :invalid_token}
 
@@ -345,7 +345,7 @@ defmodule Tune.Spotify.Session.HTTP do
   end
 
   def handle_event(:internal, :get_devices, :authenticated, data) do
-    case HttpApi.get_devices(data.credentials.token) do
+    case spotify_client().get_devices(data.credentials.token) do
       {:error, :invalid_token} ->
         {:stop, :invalid_token}
 
@@ -370,8 +370,8 @@ defmodule Tune.Spotify.Session.HTTP do
   end
 
   def handle_event(:state_timeout, :refresh_data, :authenticated, data) do
-    with {:ok, now_playing} <- HttpApi.now_playing(data.credentials.token),
-         {:ok, devices} <- HttpApi.get_devices(data.credentials.token) do
+    with {:ok, now_playing} <- spotify_client().now_playing(data.credentials.token),
+         {:ok, devices} <- spotify_client().get_devices(data.credentials.token) do
       if data.now_playing !== now_playing do
         broadcast(data.session_id, {:now_playing, now_playing})
       end
@@ -446,7 +446,7 @@ defmodule Tune.Spotify.Session.HTTP do
   end
 
   defp handle_authenticated_call(from, :toggle_play, %{now_playing: %{status: :playing}} = data) do
-    case HttpApi.pause(data.credentials.token) do
+    case spotify_client().pause(data.credentials.token) do
       :ok ->
         actions = [
           {:next_event, :internal, :get_now_playing},
@@ -461,7 +461,7 @@ defmodule Tune.Spotify.Session.HTTP do
   end
 
   defp handle_authenticated_call(from, :toggle_play, %{now_playing: %{status: :paused}} = data) do
-    case HttpApi.play(data.credentials.token) do
+    case spotify_client().play(data.credentials.token) do
       :ok ->
         actions = [
           {:next_event, :internal, :get_now_playing},
@@ -481,7 +481,7 @@ defmodule Tune.Spotify.Session.HTTP do
   end
 
   defp handle_authenticated_call(from, {:search, q, opts}, data) do
-    case HttpApi.search(data.credentials.token, q, opts) do
+    case spotify_client().search(data.credentials.token, q, opts) do
       {:ok, results} ->
         action = {:reply, from, {:ok, results}}
         {:keep_state_and_data, action}
@@ -492,7 +492,7 @@ defmodule Tune.Spotify.Session.HTTP do
   end
 
   defp handle_authenticated_call(from, {:top_tracks, opts}, data) do
-    case HttpApi.top_tracks(data.credentials.token, opts) do
+    case spotify_client().top_tracks(data.credentials.token, opts) do
       {:ok, tracks} ->
         action = {:reply, from, {:ok, tracks}}
         {:keep_state_and_data, action}
@@ -503,7 +503,7 @@ defmodule Tune.Spotify.Session.HTTP do
   end
 
   defp handle_authenticated_call(from, {:play, uri}, data) do
-    case HttpApi.play(data.credentials.token, uri) do
+    case spotify_client().play(data.credentials.token, uri) do
       :ok ->
         actions = [
           {:next_event, :internal, :get_now_playing},
@@ -518,7 +518,7 @@ defmodule Tune.Spotify.Session.HTTP do
   end
 
   defp handle_authenticated_call(from, {:play, uri, context_uri}, data) do
-    case HttpApi.play(data.credentials.token, uri, context_uri) do
+    case spotify_client().play(data.credentials.token, uri, context_uri) do
       :ok ->
         actions = [
           {:next_event, :internal, :get_now_playing},
@@ -533,7 +533,7 @@ defmodule Tune.Spotify.Session.HTTP do
   end
 
   defp handle_authenticated_call(from, :next, data) do
-    case HttpApi.next(data.credentials.token) do
+    case spotify_client().next(data.credentials.token) do
       :ok ->
         actions = [
           {:next_event, :internal, :get_now_playing},
@@ -548,7 +548,7 @@ defmodule Tune.Spotify.Session.HTTP do
   end
 
   defp handle_authenticated_call(from, :prev, data) do
-    case HttpApi.prev(data.credentials.token) do
+    case spotify_client().prev(data.credentials.token) do
       :ok ->
         actions = [
           {:next_event, :internal, :get_now_playing},
@@ -563,7 +563,7 @@ defmodule Tune.Spotify.Session.HTTP do
   end
 
   defp handle_authenticated_call(from, {:seek, position_ms}, data) do
-    case HttpApi.seek(data.credentials.token, position_ms) do
+    case spotify_client().seek(data.credentials.token, position_ms) do
       :ok ->
         actions = [
           {:next_event, :internal, :get_now_playing},
@@ -578,7 +578,7 @@ defmodule Tune.Spotify.Session.HTTP do
   end
 
   defp handle_authenticated_call(from, {:get_album, album_id}, data) do
-    case HttpApi.get_album(data.credentials.token, album_id) do
+    case spotify_client().get_album(data.credentials.token, album_id) do
       {:ok, album} ->
         actions = [
           {:reply, from, {:ok, album}}
@@ -592,7 +592,7 @@ defmodule Tune.Spotify.Session.HTTP do
   end
 
   defp handle_authenticated_call(from, {:get_artist, artist_id}, data) do
-    case HttpApi.get_artist(data.credentials.token, artist_id) do
+    case spotify_client().get_artist(data.credentials.token, artist_id) do
       {:ok, artist} ->
         actions = [
           {:reply, from, {:ok, artist}}
@@ -606,7 +606,7 @@ defmodule Tune.Spotify.Session.HTTP do
   end
 
   defp handle_authenticated_call(from, {:get_artist_albums, artist_id, opts}, data) do
-    case HttpApi.get_artist_albums(data.credentials.token, artist_id, opts) do
+    case spotify_client().get_artist_albums(data.credentials.token, artist_id, opts) do
       {:ok, albums} ->
         actions = [
           {:reply, from, {:ok, albums}}
@@ -620,7 +620,7 @@ defmodule Tune.Spotify.Session.HTTP do
   end
 
   defp handle_authenticated_call(from, {:get_show, show_id}, data) do
-    case HttpApi.get_show(data.credentials.token, show_id) do
+    case spotify_client().get_show(data.credentials.token, show_id) do
       {:ok, show} ->
         actions = [
           {:reply, from, {:ok, show}}
@@ -634,7 +634,7 @@ defmodule Tune.Spotify.Session.HTTP do
   end
 
   defp handle_authenticated_call(from, {:get_episodes, show_id}, data) do
-    case HttpApi.get_episodes(data.credentials.token, show_id) do
+    case spotify_client().get_episodes(data.credentials.token, show_id) do
       {:ok, episodes} ->
         actions = [
           {:reply, from, {:ok, episodes}}
@@ -648,7 +648,7 @@ defmodule Tune.Spotify.Session.HTTP do
   end
 
   defp handle_authenticated_call(from, {:get_playlist, playlist_id}, data) do
-    case HttpApi.get_playlist(data.credentials.token, playlist_id) do
+    case spotify_client().get_playlist(data.credentials.token, playlist_id) do
       {:ok, playlist} ->
         actions = [
           {:reply, from, {:ok, playlist}}
@@ -672,7 +672,7 @@ defmodule Tune.Spotify.Session.HTTP do
   end
 
   defp handle_authenticated_call(from, {:get_recommendations_from_artists, artist_ids}, data) do
-    case HttpApi.get_recommendations_from_artists(data.credentials.token, artist_ids) do
+    case spotify_client().get_recommendations_from_artists(data.credentials.token, artist_ids) do
       {:ok, tracks} ->
         actions = [
           {:reply, from, {:ok, tracks}}
@@ -694,7 +694,7 @@ defmodule Tune.Spotify.Session.HTTP do
   end
 
   defp handle_authenticated_call(from, {:transfer_playback, device_id}, data) do
-    case HttpApi.transfer_playback(data.credentials.token, device_id) do
+    case spotify_client().transfer_playback(data.credentials.token, device_id) do
       :ok ->
         actions = [
           {:reply, from, :ok}
@@ -708,7 +708,7 @@ defmodule Tune.Spotify.Session.HTTP do
   end
 
   defp handle_authenticated_call(from, {:set_volume, volume_percent}, data) do
-    case HttpApi.set_volume(data.credentials.token, volume_percent) do
+    case spotify_client().set_volume(data.credentials.token, volume_percent) do
       :ok ->
         actions = [
           {:next_event, :internal, :get_now_playing},
@@ -741,4 +741,6 @@ defmodule Tune.Spotify.Session.HTTP do
   defp via(token) do
     {:via, Registry, {SessionRegistry, token}}
   end
+
+  defp spotify_client, do: Application.get_env(:tune, :spotify_client)
 end

--- a/lib/tune/spotify/supervisor.ex
+++ b/lib/tune/spotify/supervisor.ex
@@ -27,7 +27,7 @@ defmodule Tune.Spotify.Supervisor do
   defp start_session(id, credentials) do
     DynamicSupervisor.start_child(
       Tune.Spotify.SessionSupervisor,
-      {Tune.Spotify.Session.Worker, {id, credentials}}
+      {Tune.Spotify.Session.HTTP, {id, credentials}}
     )
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -85,10 +85,11 @@ defmodule Tune.MixProject do
       main: "readme",
       extras: ["README.md"],
       before_closing_body_tag: &monospace_stylesheet/1,
-      nest_modules_by_prefix: [Tune.Spotify.Schema, Tune.Spotify.Session],
+      nest_modules_by_prefix: [Tune.Spotify.Schema, Tune.Spotify.Session, Tune.Spotify.Client],
       groups_for_modules: [
         "Spotify Schemas": ~r/Schema/,
         "Spotify Session": ~r/Session/,
+        "Spotify Client API": ~r/Client/,
         Authentication: ~r/Auth/,
         UI: TuneWeb.ExplorerLive,
         Routing: TuneWeb.Router.Helpers,

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,4 @@
 ExUnit.start()
 
 Mox.defmock(Tune.Spotify.SessionMock, for: Tune.Spotify.Session)
+Mox.defmock(Tune.Spotify.Client.Mock, for: Tune.Spotify.Client)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,4 @@
 ExUnit.start()
 
-Mox.defmock(Tune.Spotify.SessionMock, for: Tune.Spotify.Session)
+Mox.defmock(Tune.Spotify.Session.Mock, for: Tune.Spotify.Session)
 Mox.defmock(Tune.Spotify.Client.Mock, for: Tune.Spotify.Client)

--- a/test/tune_web/live/logged_in_test.exs
+++ b/test/tune_web/live/logged_in_test.exs
@@ -102,7 +102,7 @@ defmodule TuneWeb.LoggedInTest do
 
         assert has_element?(explorer_live, "[data-test-status=playing]")
 
-        Tune.Spotify.SessionMock
+        Tune.Spotify.Session.Mock
         |> expect(:toggle_play, 1, fn ^session_id ->
           new_player = %{player | status: :paused}
           send(explorer_live.pid, {:now_playing, new_player})
@@ -115,21 +115,21 @@ defmodule TuneWeb.LoggedInTest do
 
         assert has_element?(explorer_live, "[data-test-status=paused]")
 
-        Tune.Spotify.SessionMock
+        Tune.Spotify.Session.Mock
         |> expect(:next, 1, fn ^session_id -> :ok end)
 
         assert explorer_live
                |> element("[data-test-control=next]")
                |> render_click()
 
-        Tune.Spotify.SessionMock
+        Tune.Spotify.Session.Mock
         |> expect(:prev, 1, fn ^session_id -> :ok end)
 
         assert explorer_live
                |> element("[data-test-control=prev]")
                |> render_click()
 
-        Tune.Spotify.SessionMock
+        Tune.Spotify.Session.Mock
         |> expect(:set_volume, 1, fn ^session_id, ^volume_percent -> :ok end)
 
         assert explorer_live
@@ -138,7 +138,7 @@ defmodule TuneWeb.LoggedInTest do
 
         new_position_ms = max(player.progress_ms + 100, player.item.duration_ms - 100)
 
-        Tune.Spotify.SessionMock
+        Tune.Spotify.Session.Mock
         |> expect(:seek, 1, fn ^session_id, ^new_position_ms -> :ok end)
 
         assert explorer_live
@@ -212,7 +212,7 @@ defmodule TuneWeb.LoggedInTest do
         }
       }
 
-      Tune.Spotify.SessionMock
+      Tune.Spotify.Session.Mock
       |> expect(:search, 2, fn ^session_id,
                                "example search",
                                [types: [:track], limit: 24, offset: 0] ->
@@ -250,7 +250,7 @@ defmodule TuneWeb.LoggedInTest do
         track = Enum.random(tracks)
         track_name = track.name
 
-        Tune.Spotify.SessionMock
+        Tune.Spotify.Session.Mock
         |> expect(:search, 2, fn ^session_id,
                                  ^track_name,
                                  [types: [:track], limit: 24, offset: 0] ->
@@ -295,7 +295,7 @@ defmodule TuneWeb.LoggedInTest do
         item = Enum.random(items)
         item_name = TuneWeb.SearchView.name(item)
 
-        Tune.Spotify.SessionMock
+        Tune.Spotify.Session.Mock
         |> expect(:search, 2, fn ^session_id,
                                  ^item_name,
                                  [types: [^search_type], limit: 24, offset: 0] ->
@@ -350,7 +350,7 @@ defmodule TuneWeb.LoggedInTest do
         item_name = item.name
         item_uri = item.uri
 
-        Tune.Spotify.SessionMock
+        Tune.Spotify.Session.Mock
         |> expect(:search, 2, fn ^session_id,
                                  ^item_name,
                                  [types: [^search_type], limit: 24, offset: 0] ->
@@ -383,7 +383,7 @@ defmodule TuneWeb.LoggedInTest do
 
         artist_id = artist.id
 
-        Tune.Spotify.SessionMock
+        Tune.Spotify.Session.Mock
         |> expect(:get_artist, 2, fn ^session_id, ^artist_id -> {:ok, artist} end)
         |> expect(:get_artist_albums, 2, fn ^session_id, ^artist_id, limit: 24, offset: 0 ->
           {:ok, %{albums: albums, total: Enum.count(albums)}}
@@ -408,7 +408,7 @@ defmodule TuneWeb.LoggedInTest do
 
         artist_uri = artist.uri
 
-        Tune.Spotify.SessionMock
+        Tune.Spotify.Session.Mock
         |> expect(:play, 1, fn ^session_id, ^artist_uri -> :ok end)
 
         assert explorer_live
@@ -418,7 +418,7 @@ defmodule TuneWeb.LoggedInTest do
         [album] = Enum.take_random(albums, 1)
         album_uri = album.uri
 
-        Tune.Spotify.SessionMock
+        Tune.Spotify.Session.Mock
         |> expect(:play, 1, fn ^session_id, ^album_uri -> :ok end)
 
         assert explorer_live
@@ -440,7 +440,7 @@ defmodule TuneWeb.LoggedInTest do
 
         album_id = album.id
 
-        Tune.Spotify.SessionMock
+        Tune.Spotify.Session.Mock
         |> expect(:get_album, 2, fn ^session_id, ^album_id -> {:ok, album} end)
 
         {:ok, explorer_live, html} =
@@ -494,7 +494,7 @@ defmodule TuneWeb.LoggedInTest do
 
         album_uri = album.uri
 
-        Tune.Spotify.SessionMock
+        Tune.Spotify.Session.Mock
         |> expect(:play, 1, fn ^session_id, ^album_uri -> :ok end)
 
         assert explorer_live
@@ -504,7 +504,7 @@ defmodule TuneWeb.LoggedInTest do
         [track] = Enum.take_random(album.tracks, 1)
         track_uri = track.uri
 
-        Tune.Spotify.SessionMock
+        Tune.Spotify.Session.Mock
         |> expect(:play, 1, fn ^session_id, ^track_uri, ^album_uri -> :ok end)
 
         assert explorer_live
@@ -651,7 +651,7 @@ defmodule TuneWeb.LoggedInTest do
       expect_nothing_playing(session_id)
       expect_release_radar_playlist(session_id, release_radar_playlist)
 
-      Tune.Spotify.SessionMock
+      Tune.Spotify.Session.Mock
       |> expect(:top_tracks, 2, fn ^session_id,
                                    [limit: ^top_tracks_limit, time_range: ^time_range] ->
         {:error, 403}
@@ -671,7 +671,7 @@ defmodule TuneWeb.LoggedInTest do
   end
 
   defp expect_successful_authentication(session_id, credentials, profile) do
-    Tune.Spotify.SessionMock
+    Tune.Spotify.Session.Mock
     |> expect(:setup, 3, fn ^session_id, ^credentials -> :ok end)
     |> expect(:get_profile, 3, fn ^session_id -> profile end)
     |> expect(:get_devices, 2, fn ^session_id -> [] end)
@@ -680,7 +680,7 @@ defmodule TuneWeb.LoggedInTest do
   end
 
   defp expect_nothing_playing(session_id) do
-    Tune.Spotify.SessionMock
+    Tune.Spotify.Session.Mock
     |> expect(:now_playing, 2, fn ^session_id -> %Player{status: :not_playing} end)
   end
 
@@ -692,14 +692,14 @@ defmodule TuneWeb.LoggedInTest do
       device: device
     }
 
-    Tune.Spotify.SessionMock
+    Tune.Spotify.Session.Mock
     |> expect(:now_playing, 2, fn ^session_id -> player end)
 
     player
   end
 
   defp expect_no_release_radar_playlist(session_id) do
-    Tune.Spotify.SessionMock
+    Tune.Spotify.Session.Mock
     |> expect(:search, 2, fn ^session_id, "Release Radar", [types: [:playlist], limit: 1] ->
       {:ok, %{playlists: %{items: [], total: 0}}}
     end)
@@ -708,7 +708,7 @@ defmodule TuneWeb.LoggedInTest do
   defp expect_release_radar_playlist(session_id, playlist) do
     playlist_id = playlist.id
 
-    Tune.Spotify.SessionMock
+    Tune.Spotify.Session.Mock
     |> expect(:search, 2, fn ^session_id, "Release Radar", [types: [:playlist], limit: 1] ->
       {:ok, %{playlists: %{items: [playlist], total: 1}}}
     end)
@@ -718,14 +718,14 @@ defmodule TuneWeb.LoggedInTest do
   end
 
   defp expect_top_tracks(session_id, top_tracks, limit, time_range) do
-    Tune.Spotify.SessionMock
+    Tune.Spotify.Session.Mock
     |> expect(:top_tracks, 2, fn ^session_id, [limit: ^limit, time_range: ^time_range] ->
       {:ok, top_tracks}
     end)
   end
 
   defp expect_recommendations_from_artists(session_id, artist_ids, recommended_tracks) do
-    Tune.Spotify.SessionMock
+    Tune.Spotify.Session.Mock
     |> expect(:get_recommendations_from_artists, 2, fn ^session_id, requested_artist_ids ->
       for requested_artist_id <- requested_artist_ids do
         assert requested_artist_id in artist_ids


### PR DESCRIPTION
This PR improve behaviours usage in the `Tune.Spotify` namespace.

Specifically:

- Improves names related `Tune.Spotify.Session` (`Worker` to `HTTP` and `SessionMock` to `Session.Mock`)
- Introduces a `Tune.Spotify.Client` behaviour, responsible to define how to interact with the Spotify API. Callbacks are extracted from  `Tune.Spotify.HttpApi`, which is renamed to `Tune.Spotify.Client.HTTP` and represents the main implementation. This change lays the ground for deterministic test of `Tune.Spotify.Session.HTTP` in a future PR.

