### PR TITLE
Split CI pipeline into separate jobs

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -6,19 +6,18 @@ on:
   pull_request:
     branches: [ main ]
 
+defaults:
+  runs-on: ubuntu-latest
+
+  strategy:
+    matrix:
+      elixir: ['1.10.4']
+      otp: ['23.0.3']
+
 jobs:
-  test:
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        elixir: ['1.10.4']
-        otp: ['23.0.3']
-
+  lint:
     steps:
     - uses: actions/checkout@v2
-      with:
-        persist-credentials: false
 
     - name: Setup elixir
       uses: actions/setup-elixir@v1
@@ -46,11 +45,6 @@ jobs:
     - name: Check Credo
       run: mix credo list --format oneline
 
-    - name: Run Tests
-      run: mix test
-      env:
-        CI: "true"
-
     - name: Retrieve PLT Cache
       uses: actions/cache@v1
       id: plt-cache
@@ -66,6 +60,75 @@ jobs:
 
     - name: Run dialyzer
       run: mix dialyzer --no-check
+
+  test:
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup elixir
+      uses: actions/setup-elixir@v1
+      with:
+        elixir-version: ${{ matrix.elixir }} # Define the elixir version [required]
+        otp-version: ${{ matrix.otp }}
+
+    - name: Retrieve Mix Dependencies Cache
+      uses: actions/cache@v1
+      id: mix-cache
+      with:
+        path: deps
+        key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
+
+    - name: Install Dependencies
+      if: steps.mix-cache.outputs.cache-hit != 'true'
+      run: |
+        mix local.rebar --force
+        mix local.hex --force
+        mix deps.get
+
+    - name: Run Tests
+      run: mix test
+      env:
+        CI: "true"
+
+    - name: Build docs
+      if: github.ref == 'refs/heads/main'
+      run: mix docs
+
+    - name: Deploy docs
+      if: success() && github.ref == 'refs/heads/main'
+      uses: JamesIves/github-pages-deploy-action@3.5.9
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        BRANCH: gh-pages
+        FOLDER: doc
+
+  docs:
+    needs: [lint, test]
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
+
+    - name: Setup elixir
+      uses: actions/setup-elixir@v1
+      with:
+        elixir-version: ${{ matrix.elixir }} # Define the elixir version [required]
+        otp-version: ${{ matrix.otp }}
+
+    - name: Retrieve Mix Dependencies Cache
+      uses: actions/cache@v1
+      id: mix-cache
+      with:
+        path: deps
+        key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
+
+    - name: Install Dependencies
+      if: steps.mix-cache.outputs.cache-hit != 'true'
+      run: |
+        mix local.rebar --force
+        mix local.hex --force
+        mix deps.get
 
     - name: Build docs
       if: github.ref == 'refs/heads/main'

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -6,16 +6,15 @@ on:
   pull_request:
     branches: [ main ]
 
-defaults:
-  runs-on: ubuntu-latest
-
-  strategy:
-    matrix:
-      elixir: ['1.10.4']
-      otp: ['23.0.3']
-
 jobs:
   lint:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        elixir: ['1.10.4']
+        otp: ['23.0.3']
+
     steps:
     - uses: actions/checkout@v2
 
@@ -62,6 +61,13 @@ jobs:
       run: mix dialyzer --no-check
 
   test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        elixir: ['1.10.4']
+        otp: ['23.0.3']
+
     steps:
     - uses: actions/checkout@v2
 
@@ -103,6 +109,13 @@ jobs:
         FOLDER: doc
 
   docs:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        elixir: ['1.10.4']
+        otp: ['23.0.3']
+
     needs: [lint, test]
 
     steps:

--- a/.github/workflows/tune_ci.yml
+++ b/.github/workflows/tune_ci.yml
@@ -110,6 +110,7 @@ jobs:
 
   docs:
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
 
     strategy:
       matrix:
@@ -144,11 +145,10 @@ jobs:
         mix deps.get
 
     - name: Build docs
-      if: github.ref == 'refs/heads/main'
       run: mix docs
 
     - name: Deploy docs
-      if: success() && github.ref == 'refs/heads/main'
+      if: ${{ success() }}
       uses: JamesIves/github-pages-deploy-action@3.5.9
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tune_ci.yml
+++ b/.github/workflows/tune_ci.yml
@@ -96,18 +96,6 @@ jobs:
       env:
         CI: "true"
 
-    - name: Build docs
-      if: github.ref == 'refs/heads/main'
-      run: mix docs
-
-    - name: Deploy docs
-      if: success() && github.ref == 'refs/heads/main'
-      uses: JamesIves/github-pages-deploy-action@3.5.9
-      with:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        BRANCH: gh-pages
-        FOLDER: doc
-
   docs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/tune_ci.yml
+++ b/.github/workflows/tune_ci.yml
@@ -1,4 +1,4 @@
-name: Elixir CI
+name: Tune CI
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tune
 
-![CI Status](https://github.com/fully-forged/tune/workflows/Elixir%20CI/badge.svg)
+![CI Status](https://github.com/fully-forged/tune/workflows/Tune%20CI/badge.svg)
 
 - [Tune](#tune)
   * [About](#about)


### PR DESCRIPTION
This PR renames the Elixir CI pipeline to Tune CI, splitting it in 3 jobs: lint, test and docs.

Lint and test can run in parallel, while docs executes only on `main` and only if the other two jobs complete successfully.

This change shortens the general duration of the pipeline and better expresses dependencies between jobs.