### PR TITLE
Add recently played albums to suggestions

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -35,6 +35,7 @@ spotify_scope =
     user-read-email
     user-read-playback-state
     user-read-private
+    user-read-recently-played
     user-top-read
   )
   |> Enum.join(",")

--- a/lib/tune/spotify/client.ex
+++ b/lib/tune/spotify/client.ex
@@ -28,6 +28,9 @@ defmodule Tune.Spotify.Client do
   @type item_type :: :album | :artist | :playlist | :track | :show | :episode | :playlist
   @type pagination_option :: {:limit, pos_integer()} | {:offset, pos_integer()}
   @type pagination_options :: [pagination_option()]
+  @type recently_played_tracks_options :: [
+          {:limit, pos_integer()} | {:after, DateTime.t()} | {:after, DateTime.t()}
+        ]
   @type search_options :: [{:types, [item_type()]} | pagination_option()]
   @type search_results :: %{
           optional(item_type()) => %{
@@ -72,6 +75,8 @@ defmodule Tune.Spotify.Client do
   @callback get_recommendations_from_artists(token(), artist_ids :: [Artist.id()]) ::
               {:ok, [Track.t()]} | {:error, term()}
   @callback get_show(token(), show_id :: Show.id()) :: {:ok, Show.t()} | {:error, term()}
+  @callback recently_played_tracks(token(), recently_played_tracks_options()) ::
+              {:ok, [Track.t()]} | {:error, term()}
   @callback search(token(), q(), search_options()) :: {:ok, search_results()} | {:error, term()}
   @callback top_tracks(token(), top_tracks_options()) :: {:ok, [Track.t()]} | {:error, term()}
 end

--- a/lib/tune/spotify/session.ex
+++ b/lib/tune/spotify/session.ex
@@ -73,6 +73,11 @@ defmodule Tune.Spotify.Session do
               {:ok, [Schema.Track.t()]} | {:error, term()}
   @callback get_show(id(), show_id :: Schema.Show.id()) ::
               {:ok, Schema.Show.t()} | {:error, term()}
+  @callback recently_played_tracks(
+              id(),
+              recently_played_tracks_options :: Client.recently_played_tracks_options()
+            ) ::
+              {:ok, [Schema.Track.t()]} | {:error, term()}
   @callback top_tracks(id(), top_tracks_options :: Client.top_tracks_options()) ::
               {:ok, [Schema.Track.t()]} | {:error, term()}
 

--- a/lib/tune/spotify/session/http.ex
+++ b/lib/tune/spotify/session/http.ex
@@ -204,6 +204,11 @@ defmodule Tune.Spotify.Session.HTTP do
   end
 
   @impl true
+  def recently_played_tracks(session_id, opts) do
+    GenStateMachine.call(via(session_id), {:recently_played_tracks, opts})
+  end
+
+  @impl true
   def seek(session_id, position_ms) do
     GenStateMachine.call(via(session_id), {:seek, position_ms})
   end
@@ -507,6 +512,17 @@ defmodule Tune.Spotify.Session.HTTP do
     case spotify_client().search(data.credentials.token, q, opts) do
       {:ok, results} ->
         action = {:reply, from, {:ok, results}}
+        {:keep_state_and_data, action}
+
+      error ->
+        handle_common_errors(error, data, from)
+    end
+  end
+
+  defp handle_authenticated_call(from, {:recently_played_tracks, opts}, data) do
+    case spotify_client().recently_played_tracks(data.credentials.token, opts) do
+      {:ok, tracks} ->
+        action = {:reply, from, {:ok, tracks}}
         {:keep_state_and_data, action}
 
       error ->

--- a/lib/tune_web/live/explorer_live.ex
+++ b/lib/tune_web/live/explorer_live.ex
@@ -64,6 +64,7 @@ defmodule TuneWeb.ExplorerLive do
     per_page: 24,
     page: 1,
     suggestions_playlist: :not_fetched,
+    suggestions_recently_played_albums: :not_fetched,
     suggestions_top_albums: :not_fetched,
     suggestions_top_albums_time_range: @default_time_range,
     suggestions_recommended_tracks: :not_fetched,
@@ -279,12 +280,15 @@ defmodule TuneWeb.ExplorerLive do
              socket.assigns.session_id,
              socket.assigns.suggestions_top_albums_time_range
            ),
+         {:ok, recently_played_tracks} <-
+           spotify_session().recently_played_tracks(socket.assigns.session_id, limit: 50),
          {:ok, recommended_tracks} <-
            get_recommendations(socket.assigns.session_id, top_tracks) do
       {:noreply,
        assign(socket,
          suggestions_playlist: playlist,
          suggestions_top_albums: Album.from_tracks(top_tracks),
+         suggestions_recently_played_albums: Album.from_tracks(recently_played_tracks),
          suggestions_recommended_tracks: recommended_tracks
        )}
     else

--- a/lib/tune_web/live/explorer_live.ex
+++ b/lib/tune_web/live/explorer_live.ex
@@ -256,6 +256,19 @@ defmodule TuneWeb.ExplorerLive do
         send_update(ProgressBarComponent, id: :progress_bar, progress_ms: player.progress_ms)
         {:noreply, socket}
 
+      :item in changes ->
+        case spotify_session().recently_played_tracks(socket.assigns.session_id, limit: 50) do
+          {:ok, recently_played_tracks} ->
+            {:noreply,
+             assign(socket,
+               suggestions_recently_played_albums: Album.from_tracks(recently_played_tracks),
+               now_playing: player
+             )}
+
+          error ->
+            handle_spotify_session_result(error, socket)
+        end
+
       true ->
         {:noreply, assign(socket, :now_playing, player)}
     end

--- a/lib/tune_web/live/explorer_live.html.leex
+++ b/lib/tune_web/live/explorer_live.html.leex
@@ -29,6 +29,7 @@
       <% :suggestions -> %>
         <%= render SuggestionsView, "index.html",
           suggestions_playlist: @suggestions_playlist,
+          suggestions_recently_played_albums: @suggestions_recently_played_albums,
           suggestions_top_albums: @suggestions_top_albums,
           suggestions_top_albums_time_range: @suggestions_top_albums_time_range,
           suggestions_recommended_tracks: @suggestions_recommended_tracks,

--- a/lib/tune_web/templates/suggestions/index.html.eex
+++ b/lib/tune_web/templates/suggestions/index.html.eex
@@ -6,6 +6,17 @@
   <% playlist -> %>
     <%= render PlaylistView, "show.html", playlist: playlist, now_playing: @now_playing, socket: @socket %>
   <% end %>
+
+<%= case @suggestions_recently_played_albums do %>
+  <% :not_fetched -> %>
+    <%= content_tag :p, gettext("Cannot display recently played albums.") %>
+  <% albums -> %>
+    <%= render "recently_played_albums.html",
+      albums: albums,
+      now_playing: @now_playing,
+      socket: @socket %>
+  <% end %>
+
 <%= case @suggestions_top_albums do %>
   <% :not_fetched -> %>
     <%= content_tag :p, gettext("Cannot display top albums.") %>

--- a/lib/tune_web/templates/suggestions/recently_played_albums.html.eex
+++ b/lib/tune_web/templates/suggestions/recently_played_albums.html.eex
@@ -1,0 +1,11 @@
+<article class="top-albums">
+  <div class="filter">
+    <div class="meta">
+      <%= content_tag :h1, gettext("Recently Played Albums") %>
+      <%= content_tag :p, gettext("Generated from Recently Played Tracks.") %>
+    </div>
+  </div>
+  <div class="results">
+    <%= render_many @albums, TuneWeb.SearchView, "result.html", as: :item, socket: @socket %>
+  </div>
+</article>

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -52,12 +52,12 @@ msgid "Logged out"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:426
+#: lib/tune_web/live/explorer_live.ex:439
 msgid "No available devices"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:430
+#: lib/tune_web/live/explorer_live.ex:443
 msgid "Spotify error: %{reason}"
 msgstr ""
 
@@ -266,27 +266,27 @@ msgid "The app has been updated."
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:379
+#: lib/tune_web/live/explorer_live.ex:392
 msgid "Album details"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:386
+#: lib/tune_web/live/explorer_live.ex:399
 msgid "Album details for %{name}"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:355
+#: lib/tune_web/live/explorer_live.ex:368
 msgid "Artist details"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:370
+#: lib/tune_web/live/explorer_live.ex:383
 msgid "Artist details for %{name}"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:413
+#: lib/tune_web/live/explorer_live.ex:426
 msgid "Episode details"
 msgstr ""
 
@@ -296,27 +296,27 @@ msgid "Home"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:308
+#: lib/tune_web/live/explorer_live.ex:321
 msgid "Search results"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:322
+#: lib/tune_web/live/explorer_live.ex:335
 msgid "Search results for %{q}"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:395
+#: lib/tune_web/live/explorer_live.ex:408
 msgid "Show details"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:404
+#: lib/tune_web/live/explorer_live.ex:417
 msgid "Show details for %{name}"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:275
+#: lib/tune_web/live/explorer_live.ex:288
 msgid "Suggestions"
 msgstr ""
 

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -52,12 +52,12 @@ msgid "Logged out"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:422
+#: lib/tune_web/live/explorer_live.ex:426
 msgid "No available devices"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:426
+#: lib/tune_web/live/explorer_live.ex:430
 msgid "Spotify error: %{reason}"
 msgstr ""
 
@@ -210,8 +210,8 @@ msgid "Cannot display Release Radar."
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/templates/suggestions/index.html.eex:11
 #: lib/tune_web/templates/suggestions/index.html.eex:22
+#: lib/tune_web/templates/suggestions/index.html.eex:33
 msgid "Cannot display top albums."
 msgstr ""
 
@@ -266,27 +266,27 @@ msgid "The app has been updated."
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:375
+#: lib/tune_web/live/explorer_live.ex:379
 msgid "Album details"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:382
+#: lib/tune_web/live/explorer_live.ex:386
 msgid "Album details for %{name}"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:351
+#: lib/tune_web/live/explorer_live.ex:355
 msgid "Artist details"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:366
+#: lib/tune_web/live/explorer_live.ex:370
 msgid "Artist details for %{name}"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:409
+#: lib/tune_web/live/explorer_live.ex:413
 msgid "Episode details"
 msgstr ""
 
@@ -296,27 +296,27 @@ msgid "Home"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:304
+#: lib/tune_web/live/explorer_live.ex:308
 msgid "Search results"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:318
+#: lib/tune_web/live/explorer_live.ex:322
 msgid "Search results for %{q}"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:391
+#: lib/tune_web/live/explorer_live.ex:395
 msgid "Show details"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:400
+#: lib/tune_web/live/explorer_live.ex:404
 msgid "Show details for %{name}"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:274
+#: lib/tune_web/live/explorer_live.ex:275
 msgid "Suggestions"
 msgstr ""
 
@@ -373,4 +373,19 @@ msgstr ""
 #, elixir-format
 #: lib/tune_web/templates/layout/help.html.eex:23
 msgid "Focus device selector"
+msgstr ""
+
+#, elixir-format
+#: lib/tune_web/templates/suggestions/index.html.eex:12
+msgid "Cannot display recently played albums."
+msgstr ""
+
+#, elixir-format
+#: lib/tune_web/templates/suggestions/recently_played_albums.html.eex:5
+msgid "Generated from Recently Played Tracks."
+msgstr ""
+
+#, elixir-format
+#: lib/tune_web/templates/suggestions/recently_played_albums.html.eex:4
+msgid "Recently Played Albums"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -53,12 +53,12 @@ msgid "Logged out"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:426
+#: lib/tune_web/live/explorer_live.ex:439
 msgid "No available devices"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:430
+#: lib/tune_web/live/explorer_live.ex:443
 msgid "Spotify error: %{reason}"
 msgstr ""
 
@@ -267,27 +267,27 @@ msgid "The app has been updated."
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:379
+#: lib/tune_web/live/explorer_live.ex:392
 msgid "Album details"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:386
+#: lib/tune_web/live/explorer_live.ex:399
 msgid "Album details for %{name}"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:355
+#: lib/tune_web/live/explorer_live.ex:368
 msgid "Artist details"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:370
+#: lib/tune_web/live/explorer_live.ex:383
 msgid "Artist details for %{name}"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:413
+#: lib/tune_web/live/explorer_live.ex:426
 msgid "Episode details"
 msgstr ""
 
@@ -297,27 +297,27 @@ msgid "Home"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:308
+#: lib/tune_web/live/explorer_live.ex:321
 msgid "Search results"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:322
+#: lib/tune_web/live/explorer_live.ex:335
 msgid "Search results for %{q}"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:395
+#: lib/tune_web/live/explorer_live.ex:408
 msgid "Show details"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:404
+#: lib/tune_web/live/explorer_live.ex:417
 msgid "Show details for %{name}"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:275
+#: lib/tune_web/live/explorer_live.ex:288
 msgid "Suggestions"
 msgstr ""
 

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -53,12 +53,12 @@ msgid "Logged out"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:422
+#: lib/tune_web/live/explorer_live.ex:426
 msgid "No available devices"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:426
+#: lib/tune_web/live/explorer_live.ex:430
 msgid "Spotify error: %{reason}"
 msgstr ""
 
@@ -211,8 +211,8 @@ msgid "Cannot display Release Radar."
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/templates/suggestions/index.html.eex:11
 #: lib/tune_web/templates/suggestions/index.html.eex:22
+#: lib/tune_web/templates/suggestions/index.html.eex:33
 msgid "Cannot display top albums."
 msgstr ""
 
@@ -267,27 +267,27 @@ msgid "The app has been updated."
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:375
+#: lib/tune_web/live/explorer_live.ex:379
 msgid "Album details"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:382
+#: lib/tune_web/live/explorer_live.ex:386
 msgid "Album details for %{name}"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:351
+#: lib/tune_web/live/explorer_live.ex:355
 msgid "Artist details"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:366
+#: lib/tune_web/live/explorer_live.ex:370
 msgid "Artist details for %{name}"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:409
+#: lib/tune_web/live/explorer_live.ex:413
 msgid "Episode details"
 msgstr ""
 
@@ -297,27 +297,27 @@ msgid "Home"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:304
+#: lib/tune_web/live/explorer_live.ex:308
 msgid "Search results"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:318
+#: lib/tune_web/live/explorer_live.ex:322
 msgid "Search results for %{q}"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:391
+#: lib/tune_web/live/explorer_live.ex:395
 msgid "Show details"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:400
+#: lib/tune_web/live/explorer_live.ex:404
 msgid "Show details for %{name}"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:274
+#: lib/tune_web/live/explorer_live.ex:275
 msgid "Suggestions"
 msgstr ""
 
@@ -374,4 +374,19 @@ msgstr ""
 #, elixir-format
 #: lib/tune_web/templates/layout/help.html.eex:23
 msgid "Focus device selector"
+msgstr ""
+
+#, elixir-format
+#: lib/tune_web/templates/suggestions/index.html.eex:12
+msgid "Cannot display recently played albums."
+msgstr ""
+
+#, elixir-format
+#: lib/tune_web/templates/suggestions/recently_played_albums.html.eex:5
+msgid "Generated from Recently Played Tracks."
+msgstr ""
+
+#, elixir-format
+#: lib/tune_web/templates/suggestions/recently_played_albums.html.eex:4
+msgid "Recently Played Albums"
 msgstr ""

--- a/test/tune_web/live/logged_in_test.exs
+++ b/test/tune_web/live/logged_in_test.exs
@@ -60,6 +60,7 @@ defmodule TuneWeb.LoggedInTest do
               profile <- Generators.profile(),
               item <- Generators.playable_item(),
               second_item <- Generators.playable_item(),
+              recently_played_tracks <- uniq_list_of(Generators.track(), max_length: 24),
               device <- Generators.device()
             ) do
         conn = init_test_session(conn, spotify_id: session_id, spotify_credentials: credentials)
@@ -76,6 +77,7 @@ defmodule TuneWeb.LoggedInTest do
 
         new_player = %{player | item: second_item, progress_ms: second_item.duration_ms - 100}
 
+        expect_single_recently_played_tracks(session_id, recently_played_tracks, 50)
         send(explorer_live.pid, {:now_playing, new_player})
 
         escaped_item_name = escape(second_item.name)
@@ -743,6 +745,13 @@ defmodule TuneWeb.LoggedInTest do
   defp expect_recently_played_tracks(session_id, recently_played_tracks, limit) do
     Tune.Spotify.Session.Mock
     |> expect(:recently_played_tracks, 2, fn ^session_id, [limit: ^limit] ->
+      {:ok, recently_played_tracks}
+    end)
+  end
+
+  defp expect_single_recently_played_tracks(session_id, recently_played_tracks, limit) do
+    Tune.Spotify.Session.Mock
+    |> expect(:recently_played_tracks, 1, fn ^session_id, [limit: ^limit] ->
       {:ok, recently_played_tracks}
     end)
   end


### PR DESCRIPTION
This PR adds a new section in the suggestions page to show the most recently played albums (inferred from most recently played tracks).

The section automatically refreshes when the currently played item changes.

<img width="964" alt="Screenshot 2020-09-23 at 12 21 28" src="https://user-images.githubusercontent.com/537608/94006220-6edba980-fd97-11ea-90e5-ad1a7fc5d312.png">
