### PR TITLE
Upgrade to Elixir 1.11.1 and latest OTP

### DIFF
--- a/.github/workflows/tune_ci.yml
+++ b/.github/workflows/tune_ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        elixir: ['1.11.0']
+        elixir: ['1.11.1']
         otp: ['23.1.1']
 
     steps:

--- a/.github/workflows/tune_ci.yml
+++ b/.github/workflows/tune_ci.yml
@@ -65,8 +65,8 @@ jobs:
 
     strategy:
       matrix:
-        elixir: ['1.11.0']
-        otp: ['23.0.3']
+        elixir: ['1.11.1']
+        otp: ['23.1.1']
 
     steps:
     - uses: actions/checkout@v2
@@ -102,8 +102,8 @@ jobs:
 
     strategy:
       matrix:
-        elixir: ['1.11.0']
-        otp: ['23.0.3']
+        elixir: ['1.11.1']
+        otp: ['23.1.1']
 
     needs: [lint, test]
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-elixir         1.11.0-otp-23
+elixir         1.11.1-otp-23
 erlang         23.1.1
 nodejs         12.16.3

--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,2 +1,2 @@
 erlang_version=23.1.1
-elixir_version=1.11.0
+elixir_version=1.11.1


### PR DESCRIPTION
Includes a fix to the lint and docs pipelines to use the correct OTP version