### PR TITLE
Refactor integration links

### DIFF
--- a/lib/tune/link.ex
+++ b/lib/tune/link.ex
@@ -1,4 +1,8 @@
 defmodule Tune.Link do
+  @moduledoc """
+  Provides functions to generate integration links from tracks, artists and albums.
+  """
+
   alias Tune.Spotify.Schema.{Album, Artist, Track}
 
   @spec last_fm(Album.t() | Artist.t()) :: String.t()

--- a/lib/tune/link.ex
+++ b/lib/tune/link.ex
@@ -71,10 +71,11 @@ defmodule Tune.Link do
     ])
   end
 
-  @unsafe_characters ~w(< > # % { } | \ ^ ~ [ ] ` ' ’ ")
+  @unsafe_characters ~w(< > # % { } \( \) | \ ^ ~ [ ] ` ' ’ ")
   defp parameterize(s) do
     s
     |> String.replace(@unsafe_characters, "-")
-    |> Slug.slugify(lowercase: false, separator: ?-)
+    |> Slug.slugify(lowercase: false, separator: ?-, ignore: ["-"])
+    |> Kernel.||("")
   end
 end

--- a/lib/tune/link.ex
+++ b/lib/tune/link.ex
@@ -1,0 +1,80 @@
+defmodule Tune.Link do
+  alias Tune.Spotify.Schema.{Album, Artist, Track}
+
+  @spec last_fm(Album.t() | Artist.t()) :: String.t()
+  def last_fm(%Album{} = album) do
+    artist_name =
+      album
+      |> Album.main_artist()
+      |> Map.fetch!(:name)
+
+    Path.join([
+      "https://www.last.fm/music",
+      URI.encode(artist_name),
+      URI.encode(album.name)
+    ])
+  end
+
+  def last_fm(%Artist{name: name}) do
+    Path.join([
+      "https://www.last.fm/music",
+      URI.encode(name)
+    ])
+  end
+
+  @spec last_fm(Track.t(), Album.t(), Artist.t()) :: String.t()
+  def last_fm(track, album, artist) do
+    Path.join([
+      "https://www.last.fm/music",
+      URI.encode(artist.name),
+      URI.encode(album.name),
+      URI.encode(track.name)
+    ])
+  end
+
+  @spec youtube(Album.t() | Artist.t()) :: String.t()
+  def youtube(%Album{} = album) do
+    artist_name =
+      album
+      |> Album.main_artist()
+      |> Map.fetch!(:name)
+
+    q = [search_query: artist_name <> " " <> album.name]
+    "https://www.youtube.com/results?" <> URI.encode_query(q)
+  end
+
+  def youtube(%Artist{name: name}) do
+    q = [search_query: name]
+    "https://www.youtube.com/results?" <> URI.encode_query(q)
+  end
+
+  @spec youtube(Track.t(), Artist.t()) :: String.t()
+  def youtube(track, artist) do
+    q = [search_query: artist.name <> " " <> track.name]
+    "https://www.youtube.com/results?" <> URI.encode_query(q)
+  end
+
+  @spec wikipedia(Artist.t()) :: String.t()
+  def wikipedia(artist) do
+    Path.join([
+      "https://en.wikipedia.org/wiki",
+      artist.name <> "_(band)"
+    ])
+  end
+
+  @spec musixmatch(Track.t(), Artist.t()) :: String.t()
+  def musixmatch(track, artist) do
+    Path.join([
+      "https://www.musixmatch.com/lyrics",
+      parameterize(artist.name),
+      parameterize(track.name)
+    ])
+  end
+
+  @unsafe_characters ~w(< > # % { } | \ ^ ~ [ ] ` ' ’ ")
+  defp parameterize(s) do
+    s
+    |> String.replace(@unsafe_characters, "-")
+    |> Slug.slugify(lowercase: false, separator: ?-)
+  end
+end

--- a/lib/tune_web/templates/album/show.html.eex
+++ b/lib/tune_web/templates/album/show.html.eex
@@ -23,11 +23,11 @@
             <%= content_tag :span, total_duration(@album), class: "total-duration" %>
           <% end %>
           <div class="reference-links">
-            <%= link to: last_fm_link(@album), target: "_blank", class: "svg-link last-fm" do %>
+            <%= link to: Link.last_fm(@album), target: "_blank", class: "svg-link last-fm" do %>
               <%= render TuneWeb.TrackView, "icon_last_fm.html", [] %>
               <%= content_tag :span, gettext("Open in Last.fm"), class: "visually-hidden" %>
             <% end %>
-            <%= link to: youtube_link(@album), target: "_blank", class: "svg-link youtube" do %>
+            <%= link to: Link.youtube(@album), target: "_blank", class: "svg-link youtube" do %>
               <%= render TuneWeb.TrackView, "icon_youtube.html", [] %>
               <%= content_tag :span, gettext("Open in YouTube"), class: "visually-hidden" %>
             <% end %>

--- a/lib/tune_web/templates/artist/show.html.eex
+++ b/lib/tune_web/templates/artist/show.html.eex
@@ -16,15 +16,15 @@
           <%= content_tag :h1, @artist.name %>
           <%= content_tag :p, total_albums(@artist) %>
           <div class="reference-links">
-            <%= link to: wikipedia_link(@artist), target: "_blank", class: "svg-link wikipedia" do %>
+            <%= link to: Link.wikipedia(@artist), target: "_blank", class: "svg-link wikipedia" do %>
               <%= render "icon_wikipedia.html", [] %>
               <%= content_tag :span, gettext("Open in Wikipedia"), class: "visually-hidden" %>
             <% end %>
-            <%= link to: last_fm_link(@artist), target: "_blank", class: "svg-link last-fm" do %>
+            <%= link to: Link.last_fm(@artist), target: "_blank", class: "svg-link last-fm" do %>
               <%= render TuneWeb.TrackView, "icon_last_fm.html", [] %>
               <%= content_tag :span, gettext("Open in Last.fm"), class: "visually-hidden" %>
             <% end %>
-            <%= link to: youtube_link(@artist), target: "_blank", class: "svg-link youtube" do %>
+            <%= link to: Link.youtube(@artist), target: "_blank", class: "svg-link youtube" do %>
               <%= render TuneWeb.TrackView, "icon_youtube.html", [] %>
               <%= content_tag :span, gettext("Open in YouTube"), class: "visually-hidden" %>
             <% end %>

--- a/lib/tune_web/templates/track/list.html.eex
+++ b/lib/tune_web/templates/track/list.html.eex
@@ -5,13 +5,13 @@
         <span class="track-number">&#127926;</span>
         <span class="name" phx-click="play" phx-value-uri="<%= track.uri %>" phx-value-context-uri="<%= @album.uri %>"><%= track.name %></span>
         <span class="duration"><%= Tune.Duration.hms(track.duration_ms) %></span>
-        <%= link to: last_fm_link(track, @album, @artist), class: "last-fm", target: "_blank" do %>
+        <%= link to: Link.last_fm(track, @album, @artist), class: "last-fm", target: "_blank" do %>
           <%= render "icon_last_fm.html", [] %>
         <% end %>
-        <%= link to: youtube_link(track, @artist), class: "youtube", target: "_blank" do %>
+        <%= link to: Link.youtube(track, @artist), class: "youtube", target: "_blank" do %>
           <%= render "icon_youtube.html", [] %>
         <% end %>
-        <%= link to: musixmatch_link(track, @artist), class: "lyrics", target: "_blank" do %>
+        <%= link to: Link.musixmatch(track, @artist), class: "lyrics", target: "_blank" do %>
           <%= render "icon_lyrics.html", [] %>
         <% end %>
       </li>
@@ -20,13 +20,13 @@
         <span class="track-number"><%= track.track_number %></span>
         <span class="name" phx-click="play" phx-value-uri="<%= track.uri %>" phx-value-context-uri="<%= @album.uri %>"><%= track.name %></span>
         <span class="duration"><%= Tune.Duration.hms(track.duration_ms) %></span>
-        <%= link to: last_fm_link(track, @album, @artist), class: "last-fm", target: "_blank" do %>
+        <%= link to: Link.last_fm(track, @album, @artist), class: "last-fm", target: "_blank" do %>
           <%= render "icon_last_fm.html", [] %>
         <% end %>
-        <%= link to: youtube_link(track, @artist), class: "youtube", target: "_blank" do %>
+        <%= link to: Link.youtube(track, @artist), class: "youtube", target: "_blank" do %>
           <%= render "icon_youtube.html", [] %>
         <% end %>
-        <%= link to: musixmatch_link(track, @artist), class: "lyrics", target: "_blank" do %>
+        <%= link to: Link.musixmatch(track, @artist), class: "lyrics", target: "_blank" do %>
           <%= render "icon_lyrics.html", [] %>
         <% end %>
       </li>

--- a/lib/tune_web/views/album_view.ex
+++ b/lib/tune_web/views/album_view.ex
@@ -2,7 +2,7 @@ defmodule TuneWeb.AlbumView do
   @moduledoc false
   use TuneWeb, :view
 
-  alias Tune.Spotify.Schema.Album
+  alias Tune.{Link, Spotify.Schema.Album}
   alias TuneWeb.TrackView
 
   @default_artwork "https://via.placeholder.com/300"
@@ -34,30 +34,5 @@ defmodule TuneWeb.AlbumView do
       tracks_count,
       %{formatted_duration: formatted_duration}
     )
-  end
-
-  @spec last_fm_link(Album.t()) :: String.t()
-  defp last_fm_link(album) do
-    artist_name =
-      album
-      |> Album.main_artist()
-      |> Map.fetch!(:name)
-
-    Path.join([
-      "https://www.last.fm/music",
-      URI.encode(artist_name),
-      URI.encode(album.name)
-    ])
-  end
-
-  @spec youtube_link(Album.t()) :: String.t()
-  defp youtube_link(album) do
-    artist_name =
-      album
-      |> Album.main_artist()
-      |> Map.fetch!(:name)
-
-    q = [search_query: artist_name <> " " <> album.name]
-    "https://www.youtube.com/results?" <> URI.encode_query(q)
   end
 end

--- a/lib/tune_web/views/artist_view.ex
+++ b/lib/tune_web/views/artist_view.ex
@@ -6,33 +6,12 @@ defmodule TuneWeb.ArtistView do
   @default_medium_thumbnail "https://via.placeholder.com/150"
 
   alias Tune.Spotify.Schema.{Album, Artist}
+  alias Tune.Link
   alias TuneWeb.PaginationView
 
   @spec artwork(Artist.t()) :: String.t()
   defp artwork(%Artist{thumbnails: thumbnails}),
     do: Map.get(thumbnails, :medium, @default_artwork)
-
-  @spec wikipedia_link(Artist.t()) :: String.t()
-  defp wikipedia_link(artist) do
-    Path.join([
-      "https://en.wikipedia.org/wiki",
-      artist.name <> "_(band)"
-    ])
-  end
-
-  @spec last_fm_link(Artist.t()) :: String.t()
-  defp last_fm_link(artist) do
-    Path.join([
-      "https://www.last.fm/music",
-      URI.encode(artist.name)
-    ])
-  end
-
-  @spec youtube_link(Artist.t()) :: String.t()
-  defp youtube_link(artist) do
-    q = [search_query: artist.name]
-    "https://www.youtube.com/results?" <> URI.encode_query(q)
-  end
 
   @spec thumbnail(Album.t()) :: String.t()
   defp thumbnail(%Album{thumbnails: thumbnails}) do

--- a/lib/tune_web/views/track_view.ex
+++ b/lib/tune_web/views/track_view.ex
@@ -2,43 +2,12 @@ defmodule TuneWeb.TrackView do
   @moduledoc false
   use TuneWeb, :view
 
-  alias Tune.Spotify.Schema.{Album, Artist, Player, Track}
+  alias Tune.Spotify.Schema.{Player, Track}
+  alias Tune.Link
 
   @spec playing?(Track.t(), Player.t()) :: boolean()
   defp playing?(%Track{id: track_id}, %Player{status: :playing, item: %{id: track_id}}),
     do: true
 
   defp playing?(_track, _now_playing), do: false
-
-  @spec last_fm_link(Track.t(), Album.t(), Artist.t()) :: String.t()
-  def last_fm_link(track, album, artist) do
-    Path.join([
-      "https://www.last.fm/music",
-      URI.encode(artist.name),
-      URI.encode(album.name),
-      URI.encode(track.name)
-    ])
-  end
-
-  @spec youtube_link(Track.t(), Artist.t()) :: String.t()
-  def youtube_link(track, artist) do
-    q = [search_query: artist.name <> " " <> track.name]
-    "https://www.youtube.com/results?" <> URI.encode_query(q)
-  end
-
-  @spec musixmatch_link(Track.t(), Artist.t()) :: String.t()
-  def musixmatch_link(track, artist) do
-    Path.join([
-      "https://www.musixmatch.com/lyrics",
-      parameterize(artist.name),
-      parameterize(track.name)
-    ])
-  end
-
-  @unsafe_characters ~w(< > # % { } | \ ^ ~ [ ] ` ' ’ ")
-  defp parameterize(s) do
-    s
-    |> String.replace(@unsafe_characters, "-")
-    |> Slug.slugify(lowercase: false, separator: ?-)
-  end
 end

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -231,7 +231,7 @@ msgid "Set volume"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/views/artist_view.ex:46
+#: lib/tune_web/views/artist_view.ex:25
 msgid "1 album"
 msgid_plural "%{count} albums"
 msgstr[0] ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -232,7 +232,7 @@ msgid "Set volume"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/views/artist_view.ex:46
+#: lib/tune_web/views/artist_view.ex:25
 msgid "1 album"
 msgid_plural "%{count} albums"
 msgstr[0] ""

--- a/test/tune/link_test.exs
+++ b/test/tune/link_test.exs
@@ -129,12 +129,21 @@ defmodule Tune.LinkTest do
         assert track_uri.host == "www.musixmatch.com"
 
         assert track_uri.path =~ "/lyrics/"
-        unsafe_characters = ~w(< > # % { } | \ ^ ~ [ ] ` ' ’ ")
+        unsafe_characters = ~w(< > # % \( \) { } | \ ^ ~ [ ] ` ' ’ ")
 
         for unsafe_character <- unsafe_characters do
           refute String.contains?(track_uri.path, unsafe_character)
         end
       end
+    end
+
+    test "edge cases" do
+      track = pick(Generators.track())
+      main_artist = Album.main_artist(track.album)
+
+      track = %{track | name: "(-)"}
+
+      assert is_binary(Link.musixmatch(track, main_artist))
     end
   end
 end

--- a/test/tune/link_test.exs
+++ b/test/tune/link_test.exs
@@ -1,0 +1,140 @@
+defmodule Tune.LinkTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Tune.{Link, Generators, Spotify.Schema.Album}
+
+  describe "youtube" do
+    property "it generates well-formed links" do
+      check all(track <- Generators.track()) do
+        main_artist = Album.main_artist(track.album)
+
+        album_uri =
+          track.album
+          |> Link.youtube()
+          |> URI.parse()
+
+        assert album_uri.scheme == "https"
+        assert album_uri.authority == "www.youtube.com"
+        assert album_uri.host == "www.youtube.com"
+        assert album_uri.path == "/results"
+        assert album_uri.query =~ "search_query="
+        assert album_uri.query =~ URI.encode(track.album.name)
+        assert album_uri.query =~ URI.encode(main_artist.name)
+
+        artist_uri =
+          main_artist
+          |> Link.youtube()
+          |> URI.parse()
+
+        assert artist_uri.scheme == "https"
+        assert artist_uri.authority == "www.youtube.com"
+        assert artist_uri.host == "www.youtube.com"
+        assert artist_uri.path == "/results"
+        assert artist_uri.query =~ "search_query="
+        assert artist_uri.query =~ URI.encode(main_artist.name)
+
+        track_uri =
+          track
+          |> Link.youtube(main_artist)
+          |> URI.parse()
+
+        assert track_uri.scheme == "https"
+        assert track_uri.authority == "www.youtube.com"
+        assert track_uri.host == "www.youtube.com"
+        assert track_uri.path == "/results"
+        assert track_uri.query =~ "search_query="
+        assert track_uri.query =~ URI.encode(main_artist.name)
+        assert track_uri.query =~ URI.encode(track.name)
+      end
+    end
+  end
+
+  describe "last.fm" do
+    property "it generates well-formed links" do
+      check all(track <- Generators.track()) do
+        main_artist = Album.main_artist(track.album)
+
+        album_uri =
+          track.album
+          |> Link.last_fm()
+          |> URI.parse()
+
+        assert album_uri.scheme == "https"
+        assert album_uri.authority == "www.last.fm"
+        assert album_uri.host == "www.last.fm"
+
+        assert album_uri.path ==
+                 "/music/#{URI.encode(main_artist.name)}/#{URI.encode(track.album.name)}"
+
+        artist_uri =
+          main_artist
+          |> Link.last_fm()
+          |> URI.parse()
+
+        assert artist_uri.scheme == "https"
+        assert artist_uri.authority == "www.last.fm"
+        assert artist_uri.host == "www.last.fm"
+
+        assert artist_uri.path ==
+                 "/music/#{URI.encode(main_artist.name)}"
+
+        track_uri =
+          track
+          |> Link.last_fm(track.album, main_artist)
+          |> URI.parse()
+
+        assert track_uri.scheme == "https"
+        assert track_uri.authority == "www.last.fm"
+        assert track_uri.host == "www.last.fm"
+
+        assert track_uri.path ==
+                 "/music/#{URI.encode(main_artist.name)}/#{URI.encode(track.album.name)}/#{
+                   URI.encode(track.name)
+                 }"
+      end
+    end
+  end
+
+  describe "wikipedia" do
+    property "it generates well-formed links" do
+      check all(artist <- Generators.artist()) do
+        artist_uri =
+          artist
+          |> Link.wikipedia()
+          |> URI.parse()
+
+        assert artist_uri.scheme == "https"
+        assert artist_uri.authority == "en.wikipedia.org"
+        assert artist_uri.host == "en.wikipedia.org"
+
+        assert artist_uri.path ==
+                 "/wiki/#{URI.encode(artist.name)}_(band)"
+      end
+    end
+  end
+
+  describe "musixmatch" do
+    property "it generates well-formed links" do
+      check all(track <- Generators.track()) do
+        main_artist = Album.main_artist(track.album)
+
+        track_uri =
+          track
+          |> Link.musixmatch(main_artist)
+          |> URI.parse()
+
+        assert track_uri.scheme == "https"
+        assert track_uri.authority == "www.musixmatch.com"
+        assert track_uri.host == "www.musixmatch.com"
+
+        assert track_uri.path =~ "/lyrics/"
+        unsafe_characters = ~w(< > # % { } | \ ^ ~ [ ] ` ' ’ ")
+
+        for unsafe_character <- unsafe_characters do
+          refute String.contains?(track_uri.path, unsafe_character)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Includes a fix for peculiar track names (e.g. `(-)`) that can trip some link generators.