### PR TITLE
Enable filtering of albums in artist show page

### DIFF
--- a/assets/css/general.scss
+++ b/assets/css/general.scss
@@ -168,3 +168,9 @@ kbd {
     font-size: 1.4em;
   }
 }
+
+@media (max-width: 768px) {
+  .button-small {
+    padding: 0 0.8rem;
+  }
+}

--- a/assets/css/item.scss
+++ b/assets/css/item.scss
@@ -47,6 +47,16 @@
     border-bottom: 1px solid lighten($text-color, 40%);
     margin-top: 2rem;
   }
+
+  .filters {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    .button {
+      margin-bottom: 0;
+    }
+  }
 }
 
 @media (max-width: 768px) {
@@ -79,6 +89,14 @@
 
       .reference-links {
         justify-content: center;
+        margin-top: 1rem;
+      }
+    }
+
+    .filters {
+      flex-direction: column;
+
+      .pagination {
         margin-top: 1rem;
       }
     }

--- a/assets/css/pagination.scss
+++ b/assets/css/pagination.scss
@@ -1,8 +1,8 @@
 .pagination {
   display: flex;
   justify-content: flex-end;
-  margin-top: 2rem;
-  margin-bottom: 2rem;
+  margin-top: 0;
+  margin-bottom: 0;
 
   li {
     list-style-type: none;

--- a/lib/tune/spotify/client/http.ex
+++ b/lib/tune/spotify/client/http.ex
@@ -303,12 +303,19 @@ defmodule Tune.Spotify.Client.HTTP do
   def get_artist_albums(token, artist_id, opts) do
     limit = Keyword.get(opts, :limit, @default_limit)
     offset = Keyword.get(opts, :offset, @default_offset)
+    album_group = Keyword.get(opts, :album_group, :all)
 
     params = %{
       market: "from_token",
       limit: limit,
       offset: offset
     }
+
+    params =
+      case album_group do
+        :all -> params
+        other_group -> Map.put(params, :include_groups, other_group)
+      end
 
     case json_get(
            @base_url <> "/artists/" <> artist_id <> "/albums" <> "?" <> URI.encode_query(params),

--- a/lib/tune_web/live/explorer_live.html.leex
+++ b/lib/tune_web/live/explorer_live.html.leex
@@ -46,7 +46,13 @@
       <% :album_details -> %>
         <%= render AlbumView, "show.html", album: @item, now_playing: @now_playing, socket: @socket %>
       <% :artist_details -> %>
-        <%= render ArtistView, "show.html", artist: @item, now_playing: @now_playing, page: @page, per_page: @per_page, socket: @socket %>
+        <%= render ArtistView, "show.html",
+              artist: @item,
+              now_playing: @now_playing,
+              page: @page,
+              per_page: @per_page,
+              artist_albums_group: @artist_albums_group,
+              socket: @socket %>
       <% :show_details -> %>
         <%= render ShowView, "show.html", show: @item, now_playing: @now_playing, socket: @socket %>
       <% action when action in [:episode_details] -> %>

--- a/lib/tune_web/templates/artist/show.html.eex
+++ b/lib/tune_web/templates/artist/show.html.eex
@@ -32,13 +32,22 @@
         </div>
       </section>
       <section class="items">
-        <%= if @artist.total_albums > @per_page do %>
-          <%= render PaginationView, "selector.html",
-              pagination_opts: PaginationView.pagination_opts(@page, @per_page, @artist.total_albums),
-              url_fn: fn(current_page, per_page) ->
-                Routes.explorer_path(@socket, :artist_details, @artist.id, page: current_page, per_page: per_page)
-              end %>
-        <% end %>
+        <div class="filters">
+          <div class="controls button-group">
+            <%= for {album_group, label} <- album_groups() do %>
+              <% active_class = if @artist_albums_group == album_group, do: "active" %>
+              <%= live_patch label, to: Routes.explorer_path(@socket, :artist_details, @artist.id, album_group: album_group),
+                              class: "button button-small reversed #{active_class}" %>
+            <% end %>
+          </div>
+          <%= if @artist.total_albums > @per_page do %>
+            <%= render PaginationView, "selector.html",
+                pagination_opts: PaginationView.pagination_opts(@page, @per_page, @artist.total_albums),
+                url_fn: fn(current_page, per_page) ->
+                  Routes.explorer_path(@socket, :artist_details, @artist.id, page: current_page, per_page: per_page)
+                end %>
+          <% end %>
+        </div>
         <div class="results">
           <%= render_many @artist.albums, TuneWeb.ArtistView, "album.html", as: :album, socket: @socket %>
         </div>

--- a/lib/tune_web/views/artist_view.ex
+++ b/lib/tune_web/views/artist_view.ex
@@ -24,4 +24,14 @@ defmodule TuneWeb.ArtistView do
   defp total_albums(artist) do
     ngettext("1 album", "%{count} albums", artist.total_albums)
   end
+
+  defp album_groups do
+    [
+      all: gettext("All"),
+      album: gettext("Album"),
+      single: gettext("Single"),
+      appears_on: gettext("Appears On"),
+      compilation: gettext("Compilation")
+    ]
+  end
 end

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -52,17 +52,18 @@ msgid "Logged out"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:439
+#: lib/tune_web/live/explorer_live.ex:453
 msgid "No available devices"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:443
+#: lib/tune_web/live/explorer_live.ex:457
 msgid "Spotify error: %{reason}"
 msgstr ""
 
 #, elixir-format
 #: lib/tune_web/templates/header/search.html.eex:8
+#: lib/tune_web/views/artist_view.ex:31
 msgid "Album"
 msgstr ""
 
@@ -266,27 +267,27 @@ msgid "The app has been updated."
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:392
+#: lib/tune_web/live/explorer_live.ex:400
 msgid "Album details"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:399
+#: lib/tune_web/live/explorer_live.ex:407
 msgid "Album details for %{name}"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:368
+#: lib/tune_web/live/explorer_live.ex:374
 msgid "Artist details"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:383
+#: lib/tune_web/live/explorer_live.ex:391
 msgid "Artist details for %{name}"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:426
+#: lib/tune_web/live/explorer_live.ex:434
 msgid "Episode details"
 msgstr ""
 
@@ -296,27 +297,27 @@ msgid "Home"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:321
+#: lib/tune_web/live/explorer_live.ex:322
 msgid "Search results"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:335
+#: lib/tune_web/live/explorer_live.ex:336
 msgid "Search results for %{q}"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:408
+#: lib/tune_web/live/explorer_live.ex:416
 msgid "Show details"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:417
+#: lib/tune_web/live/explorer_live.ex:425
 msgid "Show details for %{name}"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:288
+#: lib/tune_web/live/explorer_live.ex:289
 msgid "Suggestions"
 msgstr ""
 
@@ -398,4 +399,24 @@ msgstr ""
 #, elixir-format
 #: lib/tune_web/controllers/auth_controller.ex:19
 msgid "Hello %{name}!\nAs you don't have a premium account, the embedded audio player and all audio controls are disabled.\n"
+msgstr ""
+
+#, elixir-format
+#: lib/tune_web/views/artist_view.ex:30
+msgid "All"
+msgstr ""
+
+#, elixir-format
+#: lib/tune_web/views/artist_view.ex:33
+msgid "Appears On"
+msgstr ""
+
+#, elixir-format
+#: lib/tune_web/views/artist_view.ex:34
+msgid "Compilation"
+msgstr ""
+
+#, elixir-format
+#: lib/tune_web/views/artist_view.ex:32
+msgid "Single"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -53,17 +53,18 @@ msgid "Logged out"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:439
+#: lib/tune_web/live/explorer_live.ex:453
 msgid "No available devices"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:443
+#: lib/tune_web/live/explorer_live.ex:457
 msgid "Spotify error: %{reason}"
 msgstr ""
 
 #, elixir-format
 #: lib/tune_web/templates/header/search.html.eex:8
+#: lib/tune_web/views/artist_view.ex:31
 msgid "Album"
 msgstr ""
 
@@ -267,27 +268,27 @@ msgid "The app has been updated."
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:392
+#: lib/tune_web/live/explorer_live.ex:400
 msgid "Album details"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:399
+#: lib/tune_web/live/explorer_live.ex:407
 msgid "Album details for %{name}"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:368
+#: lib/tune_web/live/explorer_live.ex:374
 msgid "Artist details"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:383
+#: lib/tune_web/live/explorer_live.ex:391
 msgid "Artist details for %{name}"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:426
+#: lib/tune_web/live/explorer_live.ex:434
 msgid "Episode details"
 msgstr ""
 
@@ -297,27 +298,27 @@ msgid "Home"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:321
+#: lib/tune_web/live/explorer_live.ex:322
 msgid "Search results"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:335
+#: lib/tune_web/live/explorer_live.ex:336
 msgid "Search results for %{q}"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:408
+#: lib/tune_web/live/explorer_live.ex:416
 msgid "Show details"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:417
+#: lib/tune_web/live/explorer_live.ex:425
 msgid "Show details for %{name}"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/live/explorer_live.ex:288
+#: lib/tune_web/live/explorer_live.ex:289
 msgid "Suggestions"
 msgstr ""
 
@@ -399,4 +400,24 @@ msgstr ""
 #, elixir-format
 #: lib/tune_web/controllers/auth_controller.ex:19
 msgid "Hello %{name}!\nAs you don't have a premium account, the embedded audio player and all audio controls are disabled.\n"
+msgstr ""
+
+#, elixir-format
+#: lib/tune_web/views/artist_view.ex:30
+msgid "All"
+msgstr ""
+
+#, elixir-format
+#: lib/tune_web/views/artist_view.ex:33
+msgid "Appears On"
+msgstr ""
+
+#, elixir-format
+#: lib/tune_web/views/artist_view.ex:34
+msgid "Compilation"
+msgstr ""
+
+#, elixir-format
+#: lib/tune_web/views/artist_view.ex:32
+msgid "Single"
 msgstr ""

--- a/test/tune/spotify/session/http_test.exs
+++ b/test/tune/spotify/session/http_test.exs
@@ -565,7 +565,7 @@ defmodule Tune.Spotify.Session.HTTPTest do
 
         # Get an artist's albums
 
-        opts = [limit: 10, offset: 0]
+        opts = [limit: 10, offset: 0, album_group: :all]
 
         expect_get_artist_albums(credentials.token, artist_id, albums, opts)
 

--- a/test/tune_web/live/logged_in_test.exs
+++ b/test/tune_web/live/logged_in_test.exs
@@ -387,7 +387,11 @@ defmodule TuneWeb.LoggedInTest do
 
         Tune.Spotify.Session.Mock
         |> expect(:get_artist, 2, fn ^session_id, ^artist_id -> {:ok, artist} end)
-        |> expect(:get_artist_albums, 2, fn ^session_id, ^artist_id, limit: 24, offset: 0 ->
+        |> expect(:get_artist_albums, 2, fn ^session_id,
+                                            ^artist_id,
+                                            limit: 24,
+                                            offset: 0,
+                                            album_group: :all ->
           {:ok, %{albums: albums, total: Enum.count(albums)}}
         end)
 


### PR DESCRIPTION
Uses `include_groups` filters available at https://developer.spotify.com/documentation/web-api/reference/artists/get-artists-albums/

<img width="870" alt="Screenshot 2020-10-30 at 09 01 18" src="https://user-images.githubusercontent.com/537608/97680370-7ecd6400-1a8e-11eb-85f4-ed70d735c110.png">
