### PR TITLE
Use Finch with Sentry

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -23,6 +23,7 @@ config :sentry,
   environment_name: :prod,
   enable_source_code_context: true,
   root_source_code_path: File.cwd!(),
+  client: Sentry.FinchClient,
   included_environments: [:prod]
 
 # ## SSL Support

--- a/lib/sentry/finch_client.ex
+++ b/lib/sentry/finch_client.ex
@@ -1,0 +1,28 @@
+defmodule Sentry.FinchClient do
+  @behaviour Sentry.HTTPClient
+
+  def child_spec do
+    opts = [name: Sentry.Finch]
+
+    Supervisor.child_spec(
+      %{
+        id: __MODULE__,
+        start: {Finch, :start_link, [opts]},
+        type: :supervisor
+      },
+      []
+    )
+  end
+
+  def post(url, headers, body) do
+    request = Finch.build(:post, url, headers, body)
+
+    case Finch.request(request, Sentry.Finch) do
+      {:ok, response} ->
+        {:ok, response.status, response.headers, response.body}
+
+      error ->
+        error
+    end
+  end
+end

--- a/lib/sentry/finch_client.ex
+++ b/lib/sentry/finch_client.ex
@@ -1,4 +1,8 @@
 defmodule Sentry.FinchClient do
+  @moduledoc """
+  Defines a small shim to use `Finch` as a `Sentry.HTTPClient`.
+  """
+
   @behaviour Sentry.HTTPClient
 
   def child_spec do


### PR DESCRIPTION
Sentry allows customising the http client - This PR sets it to use a small adapter around Finch, so that the application standardises around one client (compared to using Hackney just for Sentry).