### PR TITLE
Spotify sessions dashboard page

### DIFF
--- a/lib/tune/spotify/session.ex
+++ b/lib/tune/spotify/session.ex
@@ -84,4 +84,5 @@ defmodule Tune.Spotify.Session do
   ## SUBSCRIPTIONS
   @callback broadcast(id(), message()) :: :ok | {:error, term()}
   @callback subscribe(id()) :: :ok | {:error, term()}
+  @callback subscribers_count(id()) :: pos_integer()
 end

--- a/lib/tune/spotify/session/http.ex
+++ b/lib/tune/spotify/session/http.ex
@@ -164,6 +164,11 @@ defmodule Tune.Spotify.Session.HTTP do
   end
 
   @impl true
+  def subscribers_count(session_id) do
+    GenStateMachine.call(via(session_id), :subscribers_count)
+  end
+
+  @impl true
   def broadcast(session_id, message) do
     PubSub.broadcast(Tune.PubSub, session_id, message)
   end
@@ -433,6 +438,11 @@ defmodule Tune.Spotify.Session.HTTP do
     Process.monitor(pid)
     action = {:reply, from, :ok}
     {:keep_state, %{data | subscribers: new_subscribers}, action}
+  end
+
+  def handle_event({:call, from}, :subscribers_count, _state, data) do
+    action = {:reply, from, MapSet.size(data.subscribers)}
+    {:keep_state_and_data, action}
   end
 
   def handle_event({:call, from}, msg, :authenticated, data) do

--- a/lib/tune/spotify/supervisor.ex
+++ b/lib/tune/spotify/supervisor.ex
@@ -35,4 +35,13 @@ defmodule Tune.Spotify.Supervisor do
     count = DynamicSupervisor.count_children(Tune.Spotify.SessionSupervisor)
     :telemetry.execute([:tune, :session, :count], count)
   end
+
+  def clients_count do
+    Tune.Spotify.SessionRegistry
+    |> Registry.select([{{:"$1", :"$2", :_}, [], [{{:"$1", :"$2"}}]}])
+    |> Enum.map(fn {id, pid} ->
+      subscribers_count = Tune.Spotify.Session.HTTP.subscribers_count(id)
+      %{id: id, pid: pid, clients_count: subscribers_count}
+    end)
+  end
 end

--- a/lib/tune_web/live_dashboard/spotify_sessions_page.ex
+++ b/lib/tune_web/live_dashboard/spotify_sessions_page.ex
@@ -19,9 +19,10 @@ defmodule TuneWeb.LiveDashboard.SpotifySessionsPage do
     )
   end
 
-  defp fetch_session_counts(params, _node) do
+  defp fetch_session_counts(params, node) do
     clients_count =
-      Tune.Spotify.Supervisor.clients_count()
+      node
+      |> :rpc.call(Tune.Spotify.Supervisor, :clients_count, [])
       |> filter(params)
 
     {clients_count, length(clients_count)}

--- a/lib/tune_web/live_dashboard/spotify_sessions_page.ex
+++ b/lib/tune_web/live_dashboard/spotify_sessions_page.ex
@@ -48,7 +48,13 @@ defmodule TuneWeb.LiveDashboard.SpotifySessionsPage do
     ]
   end
 
-  defp filter(clients_count, _params) do
+  defp filter(clients_count, params) do
     clients_count
+    |> Enum.filter(fn session -> session_match?(session, params[:search]) end)
+    |> Enum.sort_by(fn session -> session[params[:sort_by]] end, params[:sort_dir])
+    |> Enum.take(params[:limit])
   end
+
+  defp session_match?(_session, nil), do: true
+  defp session_match?(session, search_string), do: String.contains?(session[:id], search_string)
 end

--- a/lib/tune_web/live_dashboard/spotify_sessions_page.ex
+++ b/lib/tune_web/live_dashboard/spotify_sessions_page.ex
@@ -1,0 +1,53 @@
+defmodule TuneWeb.LiveDashboard.SpotifySessionsPage do
+  @moduledoc false
+  use Phoenix.LiveDashboard.PageBuilder
+
+  @impl true
+  def menu_link(_, _) do
+    {:ok, "Spotify Sessions"}
+  end
+
+  @impl true
+  def render_page(_assigns) do
+    table(
+      columns: columns(),
+      id: :spotify_sessions,
+      row_attrs: &row_attrs/1,
+      row_fetcher: &fetch_session_counts/2,
+      rows_name: "sessions",
+      title: "Spotify Sessions"
+    )
+  end
+
+  defp fetch_session_counts(params, _node) do
+    clients_count =
+      Tune.Spotify.Supervisor.clients_count()
+      |> filter(params)
+
+    {clients_count, length(clients_count)}
+  end
+
+  defp columns do
+    [
+      %{field: :id, header: "Session ID", sortable: :asc},
+      %{
+        field: :pid,
+        header: "Worker PID",
+        format: &(&1 |> encode_pid() |> String.replace_prefix("PID", ""))
+      },
+      %{field: :clients_count, header: "Clients count", sortable: :asc}
+    ]
+  end
+
+  defp row_attrs(table) do
+    [
+      {"phx-click", "show_info"},
+      {"phx-value-info", encode_pid(table[:pid])},
+      {"phx-page-loading", true}
+    ]
+  end
+
+  defp filter(clients_count, _params) do
+    clients_count
+  end
+end

--- a/lib/tune_web/router.ex
+++ b/lib/tune_web/router.ex
@@ -59,7 +59,10 @@ defmodule TuneWeb.Router do
 
     live_dashboard "/dashboard",
       metrics: TuneWeb.Telemetry,
-      metrics_history: {TuneWeb.Telemetry.Storage, :metrics_history, []}
+      metrics_history: {TuneWeb.Telemetry.Storage, :metrics_history, []},
+      additional_pages: [
+        spotify_sessions: TuneWeb.LiveDashboard.SpotifySessionsPage
+      ]
   end
 
   defp admin_auth(conn, _opts) do


### PR DESCRIPTION
This PR adds a new Live Dashboard page that enables inspection of running Spotify sessions for the selected node.

<img width="969" alt="Screenshot 2020-11-19 at 14 31 15" src="https://user-images.githubusercontent.com/537608/99679787-40ffa200-2a74-11eb-8851-5bf7871f3f7b.png">

The table includes the session ID, PID and client devices count, with the ability to:

- Sort by session ID and client devices count
- Search by partial string match on session name
- Click on row to open the process inspector for the selected PID

On a technical level, the implementation relies on `Registry` to returns all running `Spotify.Session.HTTP` processes. As we need to apply filter, ordering and limit clauses, we need to use `Registry.select/2` first, returning all results. Only after that we can process the results as needed.

The implication of client-side filtering is that for large amounts of sessions, this logic can become a memory hog - improving on that would either require changing the data source (so stop using `Registry`) or extend `Registry` itself to provide a stream interface compatible with its internal design (e.g. with partition awareness).
