### PR TITLE
Use smaller images for search results and playlist

### DIFF
--- a/lib/tune_web/views/playlist_view.ex
+++ b/lib/tune_web/views/playlist_view.ex
@@ -2,14 +2,15 @@ defmodule TuneWeb.PlaylistView do
   @moduledoc false
   use TuneWeb, :view
 
-  alias Tune.Spotify.Schema.Playlist
+  alias Tune.Spotify.Schema
+  alias Schema.Playlist
   alias TuneWeb.{PlayerView, SearchView}
 
   @default_artwork "https://via.placeholder.com/300"
 
   @spec artwork(Playlist.t()) :: String.t()
   defp artwork(playlist),
-    do: Map.get(playlist.thumbnails, :large, @default_artwork)
+    do: resolve_thumbnail(playlist.thumbnails, [:medium, :large])
 
   defp group_label("single"), do: "Singles"
   defp group_label("album"), do: "Albums"
@@ -30,5 +31,12 @@ defmodule TuneWeb.PlaylistView do
       tracks_count,
       %{formatted_duration: formatted_duration}
     )
+  end
+
+  @spec resolve_thumbnail(Schema.thumbnails(), [Schema.thumbnail_size()]) :: String.t()
+  defp resolve_thumbnail(thumbnails, preferred_sizes) do
+    Enum.find_value(thumbnails, @default_artwork, fn {size, url} ->
+      if size in preferred_sizes, do: url
+    end)
   end
 end

--- a/lib/tune_web/views/search_view.ex
+++ b/lib/tune_web/views/search_view.ex
@@ -84,19 +84,19 @@ defmodule TuneWeb.SearchView do
 
   @spec thumbnail(result_item()) :: String.t()
   defp thumbnail(%Track{album: album}),
-    do: resolve_thumbnail(album.thumbnails, [:medium, :large])
+    do: resolve_thumbnail(album.thumbnails, [:small, :medium])
 
   defp thumbnail(%Album{thumbnails: thumbnails}),
-    do: resolve_thumbnail(thumbnails, [:medium, :large])
+    do: resolve_thumbnail(thumbnails, [:small, :medium])
 
   defp thumbnail(%Artist{thumbnails: thumbnails}),
-    do: resolve_thumbnail(thumbnails, [:medium, :large])
+    do: resolve_thumbnail(thumbnails, [:small, :medium])
 
   defp thumbnail(%Show{thumbnails: thumbnails}),
-    do: resolve_thumbnail(thumbnails, [:medium, :large])
+    do: resolve_thumbnail(thumbnails, [:small, :medium])
 
   defp thumbnail(%Episode{thumbnails: thumbnails}),
-    do: resolve_thumbnail(thumbnails, [:medium, :large])
+    do: resolve_thumbnail(thumbnails, [:small, :medium])
 
   @spec resolve_thumbnail(Schema.thumbnails(), [Schema.thumbnail_size()]) :: String.t()
   defp resolve_thumbnail(thumbnails, preferred_sizes) do

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -35,7 +35,7 @@ msgid "%{hours} and %{minutes}"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/views/album_view.ex:31 lib/tune_web/views/playlist_view.ex:27
+#: lib/tune_web/views/album_view.ex:31 lib/tune_web/views/playlist_view.ex:28
 msgid "1 track, %{formatted_duration}"
 msgid_plural "%{count} tracks, %{formatted_duration}"
 msgstr[0] ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -36,7 +36,7 @@ msgid "%{hours} and %{minutes}"
 msgstr ""
 
 #, elixir-format
-#: lib/tune_web/views/album_view.ex:31 lib/tune_web/views/playlist_view.ex:27
+#: lib/tune_web/views/album_view.ex:31 lib/tune_web/views/playlist_view.ex:28
 msgid "1 track, %{formatted_duration}"
 msgid_plural "%{count} tracks, %{formatted_duration}"
 msgstr[0] ""


### PR DESCRIPTION
Closes #181 

The home page shrinks to around 4-5MB, with 3-4MB used for images.