### PR TITLE
Refactor player id -> device name

### DIFF
--- a/assets/js/AudioPlayer.js
+++ b/assets/js/AudioPlayer.js
@@ -2,7 +2,7 @@ export default {
   player: null,
   initPlayer() {
     this.player = new Spotify.Player({
-      name: this.playerName(),
+      name: this.deviceName(),
       getOAuthToken: (cb) => {
         cb(this.token());
       },
@@ -25,8 +25,8 @@ export default {
   token() {
     return this.el.dataset.token;
   },
-  playerName() {
-    return this.el.dataset.playerId;
+  deviceName() {
+    return this.el.dataset.deviceName;
   },
   mounted() {
     if (window.spotifySDKReady) {

--- a/lib/tune/spotify/schema/device.ex
+++ b/lib/tune/spotify/schema/device.ex
@@ -4,9 +4,11 @@ defmodule Tune.Spotify.Schema.Device do
   """
 
   alias Tune.Spotify.Schema
+  alias Schema.Device.Name
 
   @type id :: Schema.id()
   @type volume_percent :: nil | 0..100
+  @type name :: String.t()
 
   @enforce_keys [
     :id,
@@ -32,8 +34,11 @@ defmodule Tune.Spotify.Schema.Device do
           is_active: boolean(),
           is_private_session: boolean(),
           is_restricted: boolean(),
-          name: String.t(),
+          name: name(),
           type: String.t(),
           volume_percent: volume_percent()
         }
+
+  @spec generate_name() :: name()
+  def generate_name, do: Name.random_slug()
 end

--- a/lib/tune/spotify/schema/device/name.ex
+++ b/lib/tune/spotify/schema/device/name.ex
@@ -1,17 +1,18 @@
-defmodule Tune.PlayerName do
+defmodule Tune.Spotify.Schema.Device.Name do
   @moduledoc """
-  This module contains logic to generate player names
-  with a reasonable degree of entropy without the need of a stateful generator.
+  This module contains logic to generate player names with a reasonable degree
+  of entropy without the need of a stateful generator.
 
   Player names are supposed to be unique for a given user/session. A user is
   likely to have < 10 clients open at any given time.
 
   To guarantee a unique player name, we start with a list of 250+ musical
-  instruments. At generation time, we pick one random instrument and
-  append a value derived from current time, rounded to the second.
+  instruments. At generation time, we pick one random instrument and append a
+  value derived from current time, rounded to the second.
 
-  Names are taken from a text list stored in priv/name_generator/instruments.txt,
-  copied from https://simple.wikipedia.org/wiki/List_of_musical_instruments.
+  Names are taken from a text list stored in
+  `priv/name_generator/instruments.txt`, copied from
+  https://simple.wikipedia.org/wiki/List_of_musical_instruments.
   """
 
   instruments_file =

--- a/lib/tune_web/live/explorer_live.ex
+++ b/lib/tune_web/live/explorer_live.ex
@@ -96,7 +96,7 @@ defmodule TuneWeb.ExplorerLive do
          socket
          |> assign(@initial_state)
          |> assign(:static_changed, static_changed?(socket))
-         |> assign_new(:player_id, &generate_player_id/0)
+         |> assign_new(:device_name, &generate_device_name/0)
          |> assign(
            session_id: session_id,
            user: user,
@@ -515,7 +515,7 @@ defmodule TuneWeb.ExplorerLive do
     end
   end
 
-  defp generate_player_id do
-    "tune-" <> Tune.PlayerName.random_slug()
+  defp generate_device_name do
+    "tune-" <> Tune.Spotify.Schema.Device.Name.random_slug()
   end
 end

--- a/lib/tune_web/live/explorer_live.ex
+++ b/lib/tune_web/live/explorer_live.ex
@@ -39,7 +39,7 @@ defmodule TuneWeb.ExplorerLive do
 
   use TuneWeb, :live_view
 
-  alias Tune.Spotify.Schema.{Album, Player, Track, User}
+  alias Tune.Spotify.Schema.{Album, Device, Player, Track, User}
 
   alias TuneWeb.{
     AlbumView,
@@ -516,6 +516,6 @@ defmodule TuneWeb.ExplorerLive do
   end
 
   defp generate_device_name do
-    "tune-" <> Tune.Spotify.Schema.Device.Name.random_slug()
+    "tune-" <> Device.generate_name()
   end
 end

--- a/lib/tune_web/live/explorer_live.html.leex
+++ b/lib/tune_web/live/explorer_live.html.leex
@@ -58,10 +58,10 @@
       <% :episode_details -> %>
         <%= render ShowView, "show.html", show: @item, now_playing: @now_playing, socket: @socket %>
       <% end %>
-    <%= live_component @socket, MiniPlayerComponent, player_id: @player_id, premium?: @premium?, now_playing: @now_playing, devices: @devices, id: :mini_player %>
+    <%= live_component @socket, MiniPlayerComponent, device_name: @device_name, premium?: @premium?, now_playing: @now_playing, devices: @devices, id: :mini_player %>
     <%= if @premium? do %>
       <script defer src="https://sdk.scdn.co/spotify-player.js"></script>
-      <%= tag :div, id: "player", phx_hook: "AudioPlayer", data_token: @player_token, data_player_id: @player_id %>
+      <%= tag :div, id: "player", phx_hook: "AudioPlayer", data_token: @player_token, data_device_name: @device_name %>
     <% end %>
   </section>
 </main>

--- a/lib/tune_web/live/mini_player_component.ex
+++ b/lib/tune_web/live/mini_player_component.ex
@@ -19,10 +19,10 @@ defmodule TuneWeb.MiniPlayerComponent do
   defp name(%Episode{name: name}), do: name
   defp name(%Track{name: name}), do: name
 
-  defp devices_options([], _player_id), do: nil
+  defp devices_options([], _device_name), do: nil
 
-  defp devices_options(devices, player_name) do
-    active_device_id =
+  defp devices_options(devices, device_name) do
+    active_device_name =
       case Enum.find(devices, fn d -> d.is_active end) do
         nil -> nil
         active_device -> active_device.id
@@ -30,12 +30,12 @@ defmodule TuneWeb.MiniPlayerComponent do
 
     devices
     |> Enum.map(fn d ->
-      if d.name == player_name do
+      if d.name == device_name do
         {d.name <> " (" <> gettext("this device") <> ")", d.id}
       else
         {d.name, d.id}
       end
     end)
-    |> options_for_select(active_device_id)
+    |> options_for_select(active_device_name)
   end
 end

--- a/lib/tune_web/live/mini_player_component.html.leex
+++ b/lib/tune_web/live/mini_player_component.html.leex
@@ -8,7 +8,7 @@
         <form action="#" method="get" phx-submit="transfer_playback">
           <%= content_tag :label, gettext("Switch playback device"), for: "device", class: "visually-hidden" %>
           <select name="device" id="device" phx-change="transfer_playback">
-            <%= devices_options(@devices, @player_id) %>
+            <%= devices_options(@devices, @device_name) %>
           </select>
           <%= content_tag :button, gettext("Select"), type: "submit" %>
         </form>


### PR DESCRIPTION
Moves generation logic under device, as devices already have a name and we just generate a new one.