### PR TITLE
Refactor global shortcuts

### DIFF
--- a/assets/css/header.scss
+++ b/assets/css/header.scss
@@ -9,7 +9,7 @@ $logo-dimension: 4rem;
   padding: 1rem;
   background-color: white;
 
-  .logo {
+  #logo {
     grid-area: logo;
     display: flex;
     align-items: center;
@@ -108,7 +108,7 @@ $logo-dimension: 4rem;
       }
     }
 
-    .logo,
+    #logo,
     .search,
     .profile,
     .links {

--- a/assets/js/GlobalShortcuts.js
+++ b/assets/js/GlobalShortcuts.js
@@ -5,9 +5,9 @@ export default {
     const modalOverlay = document.querySelector("#modal-overlay");
     const closeButton = document.querySelector("#close-button");
     const openButton = document.querySelector("#open-button");
-    const searchInput = document.getElementById("q");
-    const navBar = document.getElementById("navbar");
-    const deviceSelector = document.getElementById("device");
+    const searchInput = document.querySelector("#q");
+    const navBar = document.querySelector("#navbar");
+    const deviceSelector = document.querySelector("#device");
 
     closeButton.addEventListener("click", function () {
       modal.classList.toggle("closed");

--- a/assets/js/GlobalShortcuts.js
+++ b/assets/js/GlobalShortcuts.js
@@ -1,6 +1,6 @@
 export default {
   mounted() {
-    const logo = document.querySelector(".logo a");
+    const logo = document.querySelector("#logo a");
     const modal = document.querySelector("#help");
     const modalOverlay = document.querySelector("#modal-overlay");
     const closeButton = document.querySelector("#close-button");

--- a/lib/tune_web/templates/header/logo.html.eex
+++ b/lib/tune_web/templates/header/logo.html.eex
@@ -1,4 +1,4 @@
-<div class="logo">
+<div id="logo">
   <%= live_patch to: Routes.explorer_path(@socket, :suggestions), aria_label: gettext("Go to Suggestions") do %>
     <%= render "icon_logo.html", [] %>
   <% end %>

--- a/lib/tune_web/templates/layout/app.html.eex
+++ b/lib/tune_web/templates/layout/app.html.eex
@@ -1,6 +1,6 @@
 <header>
   <nav id="navbar">
-    <div class="logo">
+    <div id="logo">
       <%= render TuneWeb.HeaderView, "icon_logo.html" %>
     </div>
     <div class="links">


### PR DESCRIPTION
- Always use IDs for elements
- Always use `document.querySelector`