### PR TITLE
Add copyright information to album page

### DIFF
--- a/assets/css/item.scss
+++ b/assets/css/item.scss
@@ -68,6 +68,13 @@
       margin-bottom: 0;
     }
   }
+
+  .copyrights {
+    p {
+      margin-bottom: 0;
+      font-size: 1.2rem;
+    }
+  }
 }
 
 @media (max-width: 768px) {

--- a/lib/tune/spotify/client/http.ex
+++ b/lib/tune/spotify/client/http.ex
@@ -10,6 +10,7 @@ defmodule Tune.Spotify.Client.HTTP do
   alias Tune.Spotify.Schema.{
     Album,
     Artist,
+    Copyright,
     Device,
     Episode,
     Player,
@@ -766,6 +767,14 @@ defmodule Tune.Spotify.Client.HTTP do
         |> Map.get("images")
         |> parse_thumbnails(),
       genres: Map.get(item, "genres"),
+      copyrights:
+        if Map.has_key?(item, "copyrights") do
+          item
+          |> Map.get("copyrights")
+          |> Enum.map(&parse_copyright/1)
+        else
+          :not_fetched
+        end,
       tracks:
         if Map.has_key?(item, "tracks") do
           item
@@ -957,5 +966,12 @@ defmodule Tune.Spotify.Client.HTTP do
 
   defp parse_spotify_url(item) do
     get_in(item, ["external_urls", "spotify"])
+  end
+
+  defp parse_copyright(copyright) do
+    %Copyright{
+      text: Map.get(copyright, "text"),
+      type: Map.get(copyright, "type")
+    }
   end
 end

--- a/lib/tune/spotify/schema/album.ex
+++ b/lib/tune/spotify/schema/album.ex
@@ -20,6 +20,7 @@ defmodule Tune.Spotify.Schema.Album do
     :release_date_precision,
     :thumbnails,
     :genres,
+    :copyrights,
     :tracks
   ]
   defstruct [
@@ -34,6 +35,7 @@ defmodule Tune.Spotify.Schema.Album do
     :release_date_precision,
     :thumbnails,
     :genres,
+    :copyrights,
     :tracks
   ]
 
@@ -50,6 +52,7 @@ defmodule Tune.Spotify.Schema.Album do
           release_date: String.t(),
           release_date_precision: String.t(),
           genres: [String.t()],
+          copyrights: [Schema.Copyright.t()] | :not_fetched,
           thumbnails: Schema.thumbnails(),
           tracks: [Track.t()] | :not_fetched
         }
@@ -115,5 +118,14 @@ defmodule Tune.Spotify.Schema.Album do
     tracks
     |> Enum.map(& &1.album)
     |> Enum.uniq()
+  end
+
+  @spec has_copyrights?(t()) :: boolean()
+  def has_copyrights?(album) do
+    case album.copyrights do
+      :not_fetched -> false
+      [] -> false
+      _other -> true
+    end
   end
 end

--- a/lib/tune/spotify/schema/copyright.ex
+++ b/lib/tune/spotify/schema/copyright.ex
@@ -1,0 +1,10 @@
+defmodule Tune.Spotify.Schema.Copyright do
+  @moduledoc """
+  Represents copyright information for a given object.
+  """
+
+  @enforce_keys [:text, :type]
+  defstruct [:text, :type]
+
+  @type t :: %__MODULE__{text: String.t(), type: String.t()}
+end

--- a/lib/tune_web/templates/album/show.html.eex
+++ b/lib/tune_web/templates/album/show.html.eex
@@ -51,5 +51,12 @@
           <% end %>
         </div>
       </section>
+      <%= if Album.has_copyrights?(@album) do %>
+        <section class="copyrights">
+          <%= for copyright <- @album.copyrights do %>
+            <p><%= copyright.text %></p>
+          <% end %>
+        </section>
+      <% end %>
     </article>
   <% end %>

--- a/test/support/generators.ex
+++ b/test/support/generators.ex
@@ -5,6 +5,7 @@ defmodule Tune.Generators do
   alias Tune.Spotify.Schema.{
     Album,
     Artist,
+    Copyright,
     Device,
     Episode,
     Playlist,
@@ -131,6 +132,7 @@ defmodule Tune.Generators do
           genres: genres,
           release_date: release_date,
           release_date_precision: release_date_precision,
+          copyrights: :not_fetched,
           tracks: :not_fetched
         })
       end)
@@ -142,10 +144,11 @@ defmodule Tune.Generators do
       tuple(
         {id(), name(), thumbnails(), album_type(), album_group(), genres(),
          release_date(release_date_precision), artists(),
-         uniq_list_of(album_track(), min_length: 1, max_length: 32)}
+         uniq_list_of(album_track(), min_length: 1, max_length: 32),
+         uniq_list_of(copyright(), max_length: 3)}
       )
       |> bind(fn {id, name, thumbnails, album_type, album_group, genres, release_date, artists,
-                  tracks} ->
+                  tracks, copyrights} ->
         constant(%Album{
           id: id,
           uri: "spotify:album:" <> id,
@@ -158,6 +161,7 @@ defmodule Tune.Generators do
           genres: genres,
           release_date: release_date,
           release_date_precision: release_date_precision,
+          copyrights: copyrights,
           tracks: tracks
         })
       end)
@@ -330,6 +334,13 @@ defmodule Tune.Generators do
     end)
   end
 
+  def copyright do
+    tuple({copyright_type(), copyright_text()})
+    |> bind(fn {copyright_type, copyright_text} ->
+      constant(%Copyright{type: copyright_type, text: copyright_text})
+    end)
+  end
+
   def product do
     one_of([constant("premium")])
   end
@@ -367,5 +378,13 @@ defmodule Tune.Generators do
     # to make things simpler, days are capped at 28 to avoid differentiating
     # between months
     map(integer(1..28), &to_string/1)
+  end
+
+  defp copyright_type do
+    one_of([constant("C"), constant("P")])
+  end
+
+  defp copyright_text do
+    string(:printable, min_length: 16, max_length: 128)
   end
 end

--- a/test/tune_web/live/logged_in_test.exs
+++ b/test/tune_web/live/logged_in_test.exs
@@ -514,6 +514,17 @@ defmodule TuneWeb.LoggedInTest do
             end
         end
 
+        case album.copyrights do
+          [] ->
+            refute has_element?(explorer_live, ".copyrights")
+
+          copyrights ->
+            for copyright <- copyrights do
+              assert html =~ copyright.text
+              assert render(explorer_live) =~ copyright.text
+            end
+        end
+
         assert html =~
                  album
                  |> Album.total_duration_ms()


### PR DESCRIPTION
Include copyright information in album page.

![Screenshot 2021-04-11 at 10 32 43](https://user-images.githubusercontent.com/537608/114296008-88cda700-9ab1-11eb-9d5a-50a25268cfe1.png)
